### PR TITLE
Enabled coding standards checking in CI and fixed coding standards.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,6 @@ jobs:
       - image: integratedexperts/ci-builder
     steps:
       - checkout
-      - run: composer validate --strict || true
-      - run: .circleci/shellcheck.sh || true
-      - run: .circleci/phpcs.sh || true
+      - run: composer validate --strict --no-check-all
+      - run: .circleci/shellcheck.sh
+      - run: .circleci/phpcs.sh

--- a/.circleci/phpcs.sh
+++ b/.circleci/phpcs.sh
@@ -16,5 +16,5 @@ composer global require drupal/coder
 composer global require dealerdirect/phpcodesniffer-composer-installer
 
 for file in "${targets[@]}"; do
-  [ -f "${file}" ] && phpcs --standard=Drupal,DrupalPractice --colors "${file}"
+  [ -f "${file}" ] && phpcs --standard=Drupal,DrupalPractice -s --colors "${file}"
 done;

--- a/.circleci/shellcheck.sh
+++ b/.circleci/shellcheck.sh
@@ -7,8 +7,8 @@ while IFS=  read -r -d $'\0'; do
     targets+=("$REPLY")
 done < <(
   find \
-    gitlab/*.sh \
     scripts \
+    .circleci/phpcs.sh \
     .circleci/shellcheck.sh \
     -type f \
     -print0

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "govcms/scaffold-tooling",
     "description": "A variety of standard config, scripts and packages to support GovCMS scaffold.",
+    "license": "GPL-2.0-or-later",
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "drupal/chosen_lib": "2.6.0",

--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -1,14 +1,20 @@
 <?php
+
 /**
  * @file
  * Drupal 8 all environment configuration file.
  *
- * This file should contain all settings.php configurations that are needed by all environments.
+ * This file should contain all settings.php configurations that are needed by
+ * all environments.
  */
+
+// phpcs:disable Drupal.Classes.ClassFileName.NoMatch
 
 /**
  * Include standard services.yml.
  */
+// phpcs:ignore Drupal.NamingConventions.ValidGlobal.GlobalUnderScore
+global $govcms_includes;
 $settings['container_yamls'][] = $govcms_includes . '/all.services.yml';
 
 // Config directory.
@@ -23,7 +29,7 @@ if (file_exists($contrib_path . '/fast404/fast404.inc')) {
 }
 $settings['fast404_exts'] = '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
 $settings['fast404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
-$settings['fast404_whitelist'] = array('robots.txt', 'system/files');
+$settings['fast404_whitelist'] = ['robots.txt', 'system/files'];
 
 // Public, private and temporary files paths.
 $settings['file_public_path'] = 'sites/default/files';
@@ -34,20 +40,42 @@ $settings['file_temporary_path'] = 'sites/default/files/private/tmp';
 // By placing a file called 404.html in the root of their theme repository.
 // 404 pages must be less than 512KB to be used. This is a performance
 // measure to ensure transfer, memory usage and disk reads are manageable.
-if (!class_exists('govCms404Page')) {
-  class govCms404Page {
+if (!class_exists('GovCms404Page')) {
+  /**
+   * Class GovCms404Page.
+   */
+  class GovCms404Page {
 
     const MAX_FILESIZE = 5132288;
 
+    /**
+     * The filepath of the file with contents of 404 page.
+     *
+     * @var string
+     */
     protected $filepath;
 
+    /**
+     * The default contents of 404 page.
+     *
+     * @var string
+     */
     protected $default;
 
+    /**
+     * GovCms404Page constructor.
+     *
+     * @param string $fast_404_html
+     *   Default HTML contents of 404 page.
+     */
     public function __construct($fast_404_html) {
       $this->filepath = '/app/404.html';
       $this->default = $fast_404_html;
     }
 
+    /**
+     * Magic method to cast class object value to string.
+     */
     public function __toString() {
       // filesize() will check the file exists. So as long as
       // we suppress the output, it won't be an issue to not
@@ -59,10 +87,11 @@ if (!class_exists('govCms404Page')) {
 
       return file_get_contents($this->filepath);
     }
+
   }
 }
 
-$settings['fast404_html'] = new govCms404Page($settings['fast404_html']);
+$settings['fast404_html'] = new GovCms404Page($settings['fast404_html']);
 
 // Ensure redirects created with the redirect module are able to set appropriate
 // caching headers to ensure that Varnish and Akamai can cache the HTTP 301.
@@ -76,10 +105,10 @@ $config['shield.settings']['allow_cli'] = TRUE;
 // govCMS using a domain with valid SSL.
 //
 // This includes:
-//  - "*-site.test.govcms.gov.au" domains (TEST)
-//  - "*-site.govcms.gov.au" domains (PROD)
-//  - "*.gov.au" domains (PROD)
-//  - "*.org.au" domains (PROD)
+// - "*-site.test.govcms.gov.au" domains (TEST)
+// - "*-site.govcms.gov.au" domains (PROD)
+// - "*.gov.au" domains (PROD)
+// - "*.org.au" domains (PROD)
 //
 // When the domain likely does not have valid SSL, then HSTS is disabled
 // explicitly (to prevent the database values being used).

--- a/drupal/settings/development.settings.php
+++ b/drupal/settings/development.settings.php
@@ -8,6 +8,8 @@
 /**
  * Include development services yml.
  */
+// phpcs:ignore Drupal.NamingConventions.ValidGlobal.GlobalUnderScore
+global $govcms_includes;
 $settings['container_yamls'][] = $govcms_includes . '/development.services.yml';
 
 /**
@@ -35,7 +37,7 @@ $config['system.performance']['css']['preprocess'] = FALSE;
 $config['system.performance']['js']['preprocess'] = FALSE;
 
 /**
- * Disable render caches, necessary for twig files to be reloaded on every page view.
+ * Disable render caches for twig files to be reloaded on every page view.
  */
 $settings['cache']['bins']['render'] = 'cache.backend.null';
 $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';

--- a/drupal/settings/lagoon.settings.php
+++ b/drupal/settings/lagoon.settings.php
@@ -11,6 +11,8 @@
 /**
  * Include lagoon services file.
  */
+// phpcs:ignore Drupal.NamingConventions.ValidGlobal.GlobalUnderScore
+global $govcms_includes;
 $settings['container_yamls'][] = $govcms_includes . '/lagoon.services.yml';
 
 // Configuration path settings.
@@ -28,11 +30,11 @@ $databases['default']['default'] = [
   'collation' => 'utf8mb4_general_ci',
 ];
 
-// Lagoon Solr connection
+// Lagoon Solr connection.
 $config['search_api.server']['backend_config']['connector_config']['host'] = getenv('SOLR_HOST') ?: 'solr';
 $config['search_api.server']['backend_config']['connector_config']['path'] = '/solr/' . getenv('SOLR_CORE') ?: 'drupal';
 
-// Lagoon Varnish & reverse proxy settings
+// Lagoon Varnish & reverse proxy settings.
 $varnish_control_port = getenv('VARNISH_CONTROL_PORT') ?: '6082';
 $varnish_hosts = explode(',', getenv('VARNISH_HOSTS') ?: 'varnish');
 array_walk($varnish_hosts, function (&$value, $key) use ($varnish_control_port) {
@@ -53,20 +55,24 @@ if (getenv('ENABLE_REDIS')) {
 
   $settings['cache_prefix']['default'] = getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
 
-  # Do not set the cache during installations of Drupal
+  // Do not set the cache during installations of Drupal.
   if (!drupal_installation_attempted()) {
     $settings['cache']['default'] = 'cache.backend.redis';
 
     // Include the default example.services.yml from the module, which will
-    // replace all supported backend services (that currently includes the cache tags
-    // checksum service and the lock backends, check the file for the current list)
+    // replace all supported backend services (that currently includes the cache
+    // tags checksum service and the lock backends, check the file for the
+    // current list).
     $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
 
     // Allow the services to work before the Redis module itself is enabled.
     $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
 
-    // Manually add the classloader path, this is required for the container cache bin definition below
-    // and allows to use it without the redis module being enabled.
+    // Manually add the classloader path, this is required for the container
+    // cache bin definition below and allows to use it without the redis module
+    // being enabled.
+    // phpcs:ignore Drupal.NamingConventions.ValidGlobal.GlobalUnderScore
+    global $class_loader;
     $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
 
     // Use redis for container cache.
@@ -82,7 +88,11 @@ if (getenv('ENABLE_REDIS')) {
         ],
         'cache.backend.redis' => [
           'class' => 'Drupal\redis\Cache\CacheBackendFactory',
-          'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
+          'arguments' => [
+            '@redis.factory',
+            '@cache_tags_provider.container',
+            '@serialization.phpserialize',
+          ],
         ],
         'cache.container' => [
           'class' => '\Drupal\redis\Cache\PhpRedis',
@@ -105,7 +115,7 @@ if (getenv('ENABLE_REDIS')) {
 $config['clamav.settings']['scan_mode'] = 1;
 $config['clamav.settings']['mode_executable']['executable_path'] = '/usr/bin/clamscan';
 
-// Hash Salt
+// Hash Salt.
 $settings['hash_salt'] = hash('sha256', getenv('LAGOON_PROJECT'));
 
 // Environment specific settings files.

--- a/drupal/settings/production.settings.php
+++ b/drupal/settings/production.settings.php
@@ -8,22 +8,25 @@
 /**
  * Include production.services.yml.
  */
+// phpcs:ignore Drupal.NamingConventions.ValidGlobal.GlobalUnderScore
+global $govcms_includes;
 $settings['container_yamls'][] = $govcms_includes . '/production.services.yml';
 
 // Inject Google Analytics snippet on all production sites.
 $config['google_analytics.settings']['codesnippet']['after'] = "gtag('config', 'UA-54970022-1', {'name': 'govcms'}); gtag('govcms.send', 'pageview', {'anonymizeIp': true})";
 
-// Don't show any error messages on the site (will still be shown in watchdog)
+// Don't show any error messages on the site (will still be shown in watchdog).
 $config['system.logging']['error_level'] = 'hide';
 
-// Expiration of cached pages on Varnish to 15 min
+// Expiration of cached pages on Varnish to 15 min.
 $config['system.performance']['cache']['page']['max_age'] = 900;
 
-// Aggregate CSS files on
+// Aggregate CSS files on.
 $config['system.performance']['css']['preprocess'] = 1;
 
-// Aggregate JavaScript files on
+// Aggregate JavaScript files on.
 $config['system.performance']['js']['preprocess'] = 1;
 
-// Disabling stage file proxy on production, with that the module can be enabled even on production
-$config['stage_file_proxy.settings']['origin'] = false;
+// Disabling stage file proxy on production, with that the module can be enabled
+// even on production.
+$config['stage_file_proxy.settings']['origin'] = FALSE;

--- a/scripts/govcms-deploy
+++ b/scripts/govcms-deploy
@@ -16,13 +16,15 @@ mkdir -p /app/web/sites/default/files/private/tmp/
 
 # Check for presence of config files.
 set +e # Prevent script failure when assigning 0.
-config_count=`ls -1 /app/config/default/*.yml 2>/dev/null | wc -l`
-dev_config_count=`ls -1 /app/config/dev/*.yml 2>/dev/null | wc -l`
+# shellcheck disable=SC2012
+config_count=$(ls -1 /app/config/default/*.yml 2>/dev/null | wc -l)
+# shellcheck disable=SC2012
+dev_config_count=$(ls -1 /app/config/dev/*.yml 2>/dev/null | wc -l)
 set -e
 
 echo "Running govcms-deploy"
 echo "Environment type: $LAGOON_ENVIRONMENT_TYPE"
-echo "Config strategy: $GOVCMS_DEPLOY_WORKFLOW_CONFIG"
+echo "Config strategy:  $GOVCMS_DEPLOY_WORKFLOW_CONFIG"
 echo "Content strategy: $GOVCMS_DEPLOY_WORKFLOW_CONTENT"
 echo "There are ${config_count} config yaml files, and ${dev_config_count} dev yaml files."
 drush core:status

--- a/scripts/tests/govcms-audit
+++ b/scripts/tests/govcms-audit
@@ -2,8 +2,8 @@
 IFS=$'\n\t'
 set -euo pipefail
 
-APP_DIR=${APP_DIR:-/app}
-CUR_DIR=$(pwd)
+APP_DIR="${APP_DIR:-/app}"
+CUR_DIR="$(pwd)"
 
 # @todo. Review.
 # This seems a bit weird. We need audit-site to copy into the project so it can
@@ -20,4 +20,4 @@ fi
 cd "$APP_DIR/audit-site"
 ./vendor/bin/drutiny profile:run d8-full --exit-on-severity=high @self
 
-cd $CUR_DIR
+cd "$CUR_DIR"

--- a/scripts/tests/govcms-behat
+++ b/scripts/tests/govcms-behat
@@ -3,7 +3,7 @@ IFS=$'\n\t'
 set -euo pipefail
 # Behat testing.
 
-APP_DIR=${APP_DIR:-/app}
-BEHAT_PROFILE=${BEHAT_PROFILE:-}
+APP_DIR="${APP_DIR:-/app}"
+BEHAT_PROFILE="${BEHAT_PROFILE:-}"
 
-${APP_DIR}/vendor/bin/behat --config ${APP_DIR}/tests/behat/behat.yml --strict --colors $BEHAT_PROFILE "$@"
+"${APP_DIR}"/vendor/bin/behat --config "${APP_DIR}"/tests/behat/behat.yml --strict --colors "$BEHAT_PROFILE" "$@"

--- a/scripts/tests/govcms-lint
+++ b/scripts/tests/govcms-lint
@@ -6,15 +6,15 @@ set -euo pipefail
 # Pass in path to lint, eg ./vendor/bin/lint web/modules/custom.
 
 # Allow path override.
-APP_DIR=${APP_DIR:-$PWD}
+APP_DIR="${APP_DIR:-$PWD}"
 
 # Lint code.
-touch ${APP_DIR}/"$@"/index.php # Avoid "no files found" error. @see https://github.com/JakubOnderka/PHP-Parallel-Lint/issues/108
-${APP_DIR}/vendor/bin/parallel-lint --exclude ./tests/vendor -e php,inc,module,theme,install,profile,test ${APP_DIR}/"$@"
-rm ${APP_DIR}/"$@"/index.php
+touch "${APP_DIR}"/"$*"/index.php # Avoid "no files found" error. @see https://github.com/JakubOnderka/PHP-Parallel-Lint/issues/108
+"${APP_DIR}"/vendor/bin/parallel-lint --exclude ./tests/vendor -e php,inc,module,theme,install,profile,test "${APP_DIR}"/"$*"
+rm "${APP_DIR}"/"$*"/index.php
 
 # Check code standards.
-${APP_DIR}/vendor/bin/phpcs --standard=${APP_DIR}/tests/phpcs.xml ${APP_DIR}/"$@"
+"${APP_DIR}"/vendor/bin/phpcs --standard="${APP_DIR}"/tests/phpcs.xml "${APP_DIR}"/"$*"
 
 # Check code mess.
-${APP_DIR}/vendor/bin/phpmd ${APP_DIR}/"$@" text codesize,unusedcode,cleancode
+"${APP_DIR}"/vendor/bin/phpmd "${APP_DIR}"/"$*" text codesize,unusedcode,cleancode

--- a/scripts/tests/govcms-lint-distro
+++ b/scripts/tests/govcms-lint-distro
@@ -3,23 +3,23 @@ IFS=$'\n\t'
 set -euo pipefail
 # Code linting for GovCMS project.
 
-APP_DIR=${APP_DIR:-/app/web}
-PROFILE_DIR=${PROFILE_DIR:-${APP_DIR}/profiles/govcms}
+APP_DIR="${APP_DIR:-/app/web}"
+PROFILE_DIR="${PROFILE_DIR:-${APP_DIR}/profiles/govcms}"
 
 # Lint code.
-${APP_DIR}/vendor/bin/parallel-lint --exclude ${APP_DIR}/tests/vendor -e php,inc,module,theme,install,profile,test \
-        ${PROFILE_DIR}/modules/custom \
-        ${PROFILE_DIR}/themes/govcms \
-        ${PROFILE_DIR}/govcms.info \
-        ${PROFILE_DIR}/govcms.install \
-        ${PROFILE_DIR}/govcms.profile \
-        ${APP_DIR}/tests
+"${APP_DIR}"/vendor/bin/parallel-lint --exclude "${APP_DIR}"/tests/vendor -e php,inc,module,theme,install,profile,test \
+  "${PROFILE_DIR}"/modules/custom \
+  "${PROFILE_DIR}"/themes/govcms \
+  "${PROFILE_DIR}"/govcms.info \
+  "${PROFILE_DIR}"/govcms.install \
+  "${PROFILE_DIR}"/govcms.profile \
+  "${APP_DIR}"/tests
 
 # Validate makefile.
-cd ${PROFILE_DIR} && drush verify-makefile
+cd "${PROFILE_DIR}" && drush verify-makefile
 
 # Check code standards.
-${APP_DIR}/vendor/bin/phpcs --standard=${PROFILE_DIR}/phpcs.xml
+"${APP_DIR}"/vendor/bin/phpcs --standard="${PROFILE_DIR}"/phpcs.xml
 
 # Check code mess.
-${APP_DIR}/vendor/bin/phpmd --ignore-violations-on-exit ${PROFILE_DIR}/modules/custom,${PROFILE_DIR}/themes/govcms,tests/behat/bootstrap,${PROFILE_DIR}/govcms.info,${PROFILE_DIR}/govcms.install,${PROFILE_DIR}/govcms.profile text codesize,unusedcode,cleancode
+"${APP_DIR}"/vendor/bin/phpmd --ignore-violations-on-exit "${PROFILE_DIR}"/modules/custom,"${PROFILE_DIR}"/themes/govcms,tests/behat/bootstrap,"${PROFILE_DIR}"/govcms.info,"${PROFILE_DIR}"/govcms.install,"${PROFILE_DIR}"/govcms.profile text codesize,unusedcode,cleancode

--- a/scripts/tests/govcms-phpunit
+++ b/scripts/tests/govcms-phpunit
@@ -6,7 +6,7 @@ set -euo pipefail
 # Pass in path to lint, eg ./vendor/bin/lint web/modules/custom.
 
 # Allow path override.
-APP_DIR=${APP_DIR:-$PWD}
+APP_DIR="${APP_DIR:-$PWD}"
 
 echo "@todo get this working"
-${APP_DIR}/vendor/bin/phpunit --bootstrap ${APP_DIR}/tests/phpunit/bootstrap.php --configuration  ${APP_DIR}/tests/phpunit/phpunit.xml "$@"
+"${APP_DIR}"/vendor/bin/phpunit --bootstrap "${APP_DIR}"/tests/phpunit/bootstrap.php --configuration "${APP_DIR}"/tests/phpunit/phpunit.xml "$@"

--- a/scripts/tests/govcms-vet
+++ b/scripts/tests/govcms-vet
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2002
+
 IFS=$'\n\t'
 set -euo pipefail
 
 exit
-
 
 #
 # If you modify anything above this line, please update all scripts in the same directory.
@@ -13,16 +14,12 @@ exit
 # want to apply from external, and best solved with an instance template coming soon
 # https://gitlab.com/gitlab-org/gitlab-ee/issues/8429
 
-SATIS="https://satis.govcms.gov.au/beta6"
 SCAFFOLD="https://github.com/govCMS/govcms8-scaffold-paas.git"
 WORKSPACE="/tmp/govcms8-scaffold-paas"
 
-STRICT=1
-WARNING=2
-
 exit_code=0
 
-flavour=$(egrep  "^type: " .version.yml | awk -F ": " '{print $2}')
+flavour=$(grep  "^type: " .version.yml | awk -F ": " '{print $2}')
 if [ "$flavour" = "saas" ] || [ "$flavour" = "paas" ] || [ "$flavour" = "saasplus" ] ; then
     echo "GovCMS build flavour: $flavour"
 else
@@ -37,7 +34,7 @@ function compare() {
         echo -e "  Expected value:\n    --$2--"
         return 1
     fi
-    echo -e "\033[0;32mOK:\033[0m" $3
+    echo -e "\033[0;32mOK:\033[0m" "$3"
     return 0
 }
 
@@ -48,25 +45,25 @@ git clone --depth=1 --quiet "$SCAFFOLD" "$WORKSPACE"
 if [ "$flavour" = "saas" ] ; then
 
     compare \
-        $(cat composer.json | jq -c '.repositories') \
-        $(cat $WORKSPACE/composer.json | jq -c '.repositories') \
+        "$(cat composer.json | jq -c '.repositories')" \
+        "$(cat $WORKSPACE/composer.json | jq -c '.repositories')" \
         "Composer repositories are expected." \
         "The repositories section of your composer.json should match the scaffold."
 
     compare \
-        $(cat composer.json | jq -c '.extra["enable-patching"]') \
-        $(cat $WORKSPACE/composer.json | jq -c '.extra["enable-patching"]') \
+        "$(cat composer.json | jq -c '.extra["enable-patching"]')" \
+        "$(cat $WORKSPACE/composer.json | jq -c '.extra["enable-patching"]')" \
         "Composer patching is enabled." \
         "Your composer.json must enable patching."
 
     compare \
-        $(cat composer.json | jq -c '.["minimum-stability"]') \
-        $(cat $WORKSPACE/composer.json | jq -c '.["minimum-stability"]') \
+        "$(cat composer.json | jq -c '.["minimum-stability"]')" \
+        "$(cat $WORKSPACE/composer.json | jq -c '.["minimum-stability"]')" \
         "Minimum stablity is dev." \
         "Your composer.json must set minimum stability to dev."
 
     compare \
-        " "$(find web/modules/custom -type f -name *.info.yml) \
+        " $(find web/modules/custom -type f -name "*.info.yml")" \
         " " \
         "No custom modules found." \
         "There should be no modules in web/sites/default/modules or web/modules"


### PR DESCRIPTION
Large PR as too many files had their coding standards violated.

No logic was touched - only fixed the part were linters were showing errors.

**Why do we need to do this cleanup now and not later?**
Because this cleanup enables future coding standards checks. We want all the future changes to be done properly, so we do not have to come back to fixing (and potentially breaking) them.