### PR TITLE
Much faster linting

### DIFF
--- a/.gitlab-ci-main.yml
+++ b/.gitlab-ci-main.yml
@@ -19,7 +19,7 @@ variables:
 .static_template: &static_template
   before_script:
     - |
-      if [ "${GOVCMS_FAST_LINTING-FALSE}" == TRUE ] ; then
+      if [ "${GOVCMS_FAST_LINTING-FALSE}" = true ] ; then
         composer update
       else
         docker network prune -f && docker network create amazeeio-network
@@ -112,7 +112,7 @@ lint:
   # Run all lines together so that they all run even if any fail.
   script: |
     set +exuo pipefail # Linting...
-    if [ "${GOVCMS_FAST_LINTING-FALSE}" == TRUE ] ; then
+    if [ "${GOVCMS_FAST_LINTING-FALSE}" = true ] ; then
       ./vendor/bin/govcms-lint web/modules/custom
       ./vendor/bin/govcms-lint web/themes/custom
     else

--- a/.gitlab-ci-main.yml
+++ b/.gitlab-ci-main.yml
@@ -15,22 +15,10 @@ variables:
 # Test setups.
 #
 
-# Minimal setup to run things like linting.
+# Minimal setup without docker, tooling available by default is https://github.com/govCMS/govcms-ci.
 .static_template: &static_template
   before_script:
-    - |
-      if [ "${GOVCMS_FAST_LINTING-FALSE}" = "TRUE" ] ; then
-        composer update
-      else
-        docker network prune -f && docker network create amazeeio-network
-        docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-
-        docker-compose up -d test
-        docker-compose ps
-
-        # Re-run composer to account for the fact the /app just got mounted over.
-        docker-compose exec -T cli bash -c 'composer install --no-interaction --no-suggest'
-      fi
+    - composer install
   stage: static
 
 # Minimal setup to execute drush against a working Drupal.
@@ -100,31 +88,28 @@ variables:
 #
 
 vet:
+  <<: *static_template
+  stage: static
   script:
     - composer validate
   when: on_success
   allow_failure: false
-  stage: static
 
 lint:
   <<: *static_template
   extends: .job-lint
   # Run all lines together so that they all run even if any fail.
-  script: |
-    set +exuo pipefail # Linting...
-    if [ "${GOVCMS_FAST_LINTING-FALSE}" = "TRUE" ] ; then
+  script:
+    - |
+      set +exuo pipefail # Linting...
       ./vendor/bin/govcms-lint web/modules/custom
       ./vendor/bin/govcms-lint web/themes/custom
-    else
-      docker-compose exec -T test bash -c '/app/vendor/bin/govcms-lint web/modules/custom'
-      docker-compose exec -T test bash -c '/app/vendor/bin/govcms-lint web/themes/custom'
-    fi
 
 unit:
   <<: *static_template
   extends: .job-unit
   script:
-    - docker-compose exec -T test bash -c './vendor/bin/govcms-unit --testsuite=unit'
+    - ./vendor/bin/govcms-unit --testsuite=unit'
 
 # Pre-flight (like a smoke test for general deployability).
 preflight:

--- a/.gitlab-ci-main.yml
+++ b/.gitlab-ci-main.yml
@@ -19,7 +19,7 @@ variables:
 .static_template: &static_template
   before_script:
     - |
-      if [ "${GOVCMS_FAST_LINTING-FALSE}" = true ] ; then
+      if [ "${GOVCMS_FAST_LINTING-FALSE}" = "TRUE" ] ; then
         composer update
       else
         docker network prune -f && docker network create amazeeio-network
@@ -112,7 +112,7 @@ lint:
   # Run all lines together so that they all run even if any fail.
   script: |
     set +exuo pipefail # Linting...
-    if [ "${GOVCMS_FAST_LINTING-FALSE}" = true ] ; then
+    if [ "${GOVCMS_FAST_LINTING-FALSE}" = "TRUE" ] ; then
       ./vendor/bin/govcms-lint web/modules/custom
       ./vendor/bin/govcms-lint web/themes/custom
     else

--- a/.gitlab-ci-main.yml
+++ b/.gitlab-ci-main.yml
@@ -19,7 +19,6 @@ variables:
 .static_template: &static_template
   before_script:
     - |
-      env
       if [ "${GOVCMS_FAST_LINTING-FALSE}" == TRUE ] ; then
         composer update
       else
@@ -113,8 +112,14 @@ lint:
   # Run all lines together so that they all run even if any fail.
   script: |
     set +exuo pipefail # Linting...
-    docker-compose exec -T test bash -c '/app/vendor/bin/govcms-lint web/modules/custom'
-    docker-compose exec -T test bash -c '/app/vendor/bin/govcms-lint web/themes/custom'
+    if [ "${GOVCMS_FAST_LINTING-FALSE}" == TRUE ] ; then
+      ./vendor/bin/govcms-lint web/modules/custom
+      ./vendor/bin/govcms-lint web/themes/custom
+    else
+      docker-compose exec -T test bash -c '/app/vendor/bin/govcms-lint web/modules/custom'
+      docker-compose exec -T test bash -c '/app/vendor/bin/govcms-lint web/themes/custom'
+    fi
+
 unit:
   <<: *static_template
   extends: .job-unit

--- a/.gitlab-ci-main.yml
+++ b/.gitlab-ci-main.yml
@@ -19,6 +19,7 @@ variables:
 .static_template: &static_template
   before_script:
     - |
+      env
       if [ "${GOVCMS_FAST_LINTING-FALSE}" == TRUE ] ; then
         composer update
       else

--- a/.gitlab-ci-main.yml
+++ b/.gitlab-ci-main.yml
@@ -109,7 +109,7 @@ unit:
   <<: *static_template
   extends: .job-unit
   script:
-    - ./vendor/bin/govcms-unit --testsuite=unit'
+    - ./vendor/bin/govcms-unit --testsuite=unit
 
 # Pre-flight (like a smoke test for general deployability).
 preflight:

--- a/.gitlab-ci-main.yml
+++ b/.gitlab-ci-main.yml
@@ -19,14 +19,18 @@ variables:
 .static_template: &static_template
   before_script:
     - |
-      docker network prune -f && docker network create amazeeio-network
-      docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+      if [ "${GOVCMS_FAST_LINTING-FALSE}" == TRUE ] ; then
+        composer update
+      else
+        docker network prune -f && docker network create amazeeio-network
+        docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
 
-      docker-compose up -d test
-      docker-compose ps
+        docker-compose up -d test
+        docker-compose ps
 
-      # Re-run composer to account for the fact the /app just got mounted over.
-      docker-compose exec -T cli bash -c 'composer install --no-interaction --no-suggest'
+        # Re-run composer to account for the fact the /app just got mounted over.
+        docker-compose exec -T cli bash -c 'composer install --no-interaction --no-suggest'
+      fi
   stage: static
 
 # Minimal setup to execute drush against a working Drupal.


### PR DESCRIPTION
Normally linting is done by bringing up the test container. This is a "best principle" method that ensures everything can be run in a standard environment, but it's also a bit silly, because linting might take 5-10 minutes on a good day.

This change allows linting to be optionally run outside the container. This may take as little as 1 minute.

It can be enabled in a project's .gitlab-ci-inputs.yml with:

```
.variables:
  GOVCMS_FAST_LINTING: "TRUE"
```

When creating `govCMS/scaffold-tooling` I tried to stick to principles of running everything in docker, but actually I think this is overkill for linting. So I would argue that there shouldn't be an option to switch it on or off, just use the fast option.




