### PR TITLE
Added tests for govcms-deploy.

### DIFF
--- a/scripts/govcms-deploy
+++ b/scripts/govcms-deploy
@@ -10,16 +10,15 @@ LAGOON_ENVIRONMENT_TYPE=${LAGOON_ENVIRONMENT_TYPE:-production}
 GOVCMS_DEPLOY_WORKFLOW_CONFIG=${GOVCMS_DEPLOY_WORKFLOW_CONFIG:-import}
 # Determine the content strategy `import` vs `retain`.
 GOVCMS_DEPLOY_WORKFLOW_CONTENT=${GOVCMS_DEPLOY_WORKFLOW_CONTENT:-retain}
-
-# Ensure tmp folder always exists.
-mkdir -p /app/web/sites/default/files/private/tmp/
+# The location of the application directory.
+APP="${APP:-/app}"
 
 # Check for presence of config files.
 set +e # Prevent script failure when assigning 0.
-# shellcheck disable=SC2012
-config_count=$(ls -1 /app/config/default/*.yml 2>/dev/null | wc -l)
-# shellcheck disable=SC2012
-dev_config_count=$(ls -1 /app/config/dev/*.yml 2>/dev/null | wc -l)
+# shellcheck disable=SC2012,SC2086
+config_count=$(ls -1 $APP/config/default/*.yml 2>/dev/null | wc -l | tr -d ' ')
+# shellcheck disable=SC2012,SC2086
+dev_config_count=$(ls -1 $APP/config/dev/*.yml 2>/dev/null | wc -l | tr -d ' ')
 set -e
 
 echo "Running govcms-deploy"
@@ -27,13 +26,18 @@ echo "Environment type: $LAGOON_ENVIRONMENT_TYPE"
 echo "Config strategy:  $GOVCMS_DEPLOY_WORKFLOW_CONFIG"
 echo "Content strategy: $GOVCMS_DEPLOY_WORKFLOW_CONTENT"
 echo "There are ${config_count} config yaml files, and ${dev_config_count} dev yaml files."
+
+# Ensure tmp folder always exists.
+mkdir -p "$APP/web/sites/default/files/private/tmp"
+
 drush core:status
 
 # Database updates, cache rebuild, optional config imports.
 common_deploy () {
 
   if [[ "$LAGOON_ENVIRONMENT_TYPE" = "development" && "$GOVCMS_DEPLOY_WORKFLOW_CONTENT" = "import" ]]; then
-    drush --alias-path=/etc/drush/sites sql-sync @ci.prod @self -y
+    echo "Performing content import."
+    drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self -y
   fi
 
   drush updatedb -y
@@ -60,7 +64,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" = "production" ]]; then
 
   if drush status --fields=bootstrap | grep -q "Successful"; then
     echo "Making a database backup."
-    mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql
+    mkdir -p "$APP/web/sites/default/files/private/backups/" && drush sql:dump --gzip --result-file="$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql"
     common_deploy
   else
     echo "Drupal is not installed or not operational."
@@ -84,3 +88,5 @@ else
   fi
 
 fi
+
+echo "Finished running govcms-deploy."

--- a/tests/bats/_helpers.bash
+++ b/tests/bats/_helpers.bash
@@ -266,6 +266,11 @@ assert_output_not_contains(){
   assert_not_contains "${expected}" "${output}"
 }
 
+mktouch(){
+  local file="${1}"
+  mkdir -p "$(dirname "${file}")" && touch "${file}"
+}
+
 # Format error message with optional output, if present.
 format_error(){
   local message="${1}"
@@ -291,4 +296,8 @@ format_error(){
 # Run bats with `--tap` option to debug the output.
 debug(){
   echo "${1}" >&3
+}
+
+debug_output(){
+  debug "${output}"
 }

--- a/tests/bats/_helpers.bash
+++ b/tests/bats/_helpers.bash
@@ -12,6 +12,22 @@ if [ -z "$TEST_PATH_INITIALIZED" ]; then
   PATH=/usr/bin:/usr/local/bin:/bin:/usr/sbin:/sbin
   # Add BATS test directory to the PATH.
   PATH="$(dirname "${BATS_TEST_DIRNAME}"):$PATH"
+
+  # BATS_TMPDIR - the location to a directory that may be used to store
+  # temporary files. Provided by bats. Created once for the duration of the
+  # whole suite run.
+  # Do not use BATS_TMPDIR, instead use BATS_TEST_TMPDIR.
+  #
+  # BATS_TEST_TMPDIR - unique location for temp files per test.
+  # shellcheck disable=SC2002
+  random_suffix=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1)
+  BATS_TEST_TMPDIR="${BATS_TMPDIR}/bats-test-tmp-${random_suffix}"
+  [ -d "${BATS_TEST_TMPDIR}" ] && rm -Rf "${BATS_TEST_TMPDIR}" > /dev/null
+  mkdir -p "${BATS_TEST_TMPDIR}"
+
+  export BATS_TEST_TMPDIR
+
+  echo "BATS_TEST_TMPDIR dir: ${BATS_TEST_TMPDIR}" >&3
 fi
 
 flunk(){

--- a/tests/bats/_helpers_govcms.bash
+++ b/tests/bats/_helpers_govcms.bash
@@ -4,7 +4,7 @@
 #
 # Include this file into every test file to access utilities and assertions.
 #
-# shellcheck disable=SC2119,SC2120
+# shellcheck disable=SC2119,SC2120,SC2034,SC2155
 
 load "${BASH_SOURCE[0]%/*}"/_helpers.bash
 load "${BASH_SOURCE[0]%/*}"/_bats-mock.bash
@@ -14,7 +14,18 @@ load "${BASH_SOURCE[0]%/*}"/_bats-mock.bash
 # implement setup() and call the same methods as in the code below (there is
 # no inheritance in Bash, so we cannot just extend parent setup()).
 setup() {
+  CUR_DIR="$PWD"
+
+  export TEST_APP_DIR=$(prepare_app_dir)
   setup_mock
+}
+
+# Prepare application directory to be used in tests.
+prepare_app_dir(){
+  APP_DIR="$BATS_TEST_TMPDIR/app"
+  rm -Rf "$APP_DIR" >/dev/null
+  mkdir -p "$APP_DIR"
+  echo "$APP_DIR"
 }
 
 # Setup mock support.
@@ -53,4 +64,14 @@ mock_command(){
   mock_file="${mock##*/}"
   ln -sf "${mock_path}/${mock_file}" "${mock_path}/${mocked_command}"
   echo "$mock"
+}
+
+fixture_config(){
+  local dir="${1?'App directory must be specified'}"
+  local count="${2?'Number of config files must be specified'}"
+
+  while [  "$count" -gt 0 ]; do
+    mktouch "$dir/config$count.yml"
+    count=$(( count - 1 ))
+  done
 }

--- a/tests/bats/govcms-deploy.bats
+++ b/tests/bats/govcms-deploy.bats
@@ -1,0 +1,991 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2002,SC2031,SC2030
+
+load _helpers_govcms
+
+################################################################################
+#                               DEFAULTS                                       #
+################################################################################
+
+@test "Defaults, no config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: production"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_contains "Making a database backup."
+  assert_dir_exists "$APP/web/sites/default/files/private/backups"
+  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 3)"
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Defaults, no config, not installed" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Failed" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: production"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  assert_output_contains "Drupal is not installed or not operational."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+################################################################################
+#                               PRODUCTION                                     #
+################################################################################
+
+@test "Production, no config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=production
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: production"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_contains "Making a database backup."
+  assert_dir_exists "$APP/web/sites/default/files/private/backups"
+  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 3)"
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Production, default and dev config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=production
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: production"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_contains "Making a database backup."
+  assert_dir_exists "$APP/web/sites/default/files/private/backups"
+  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 3)"
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Performing config import."
+  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 6)"
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Production, no config, retain config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=production
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=retain
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: production"
+  assert_output_contains "Config strategy:  retain"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_contains "Making a database backup."
+  assert_dir_exists "$APP/web/sites/default/files/private/backups"
+  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 3)"
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Production, default and dev config, retain config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=production
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=retain
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: production"
+  assert_output_contains "Config strategy:  retain"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_contains "Making a database backup."
+  assert_dir_exists "$APP/web/sites/default/files/private/backups"
+  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 3)"
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Production, default and dev config, import content" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=production
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=import
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: production"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: import"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_contains "Making a database backup."
+  assert_dir_exists "$APP/web/sites/default/files/private/backups"
+  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 3)"
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Performing config import."
+  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 6)"
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Production, no config, not installed" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Failed" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=production
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: production"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  assert_output_contains "Drupal is not installed or not operational."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+################################################################################
+#                               DEVELOPMENT                                    #
+################################################################################
+
+@test "Development, no config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: development"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Development, default and dev config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: development"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_contains "Performing config import."
+  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_output_contains "Performing development config import on non-production site."
+  assert_equal "config:import -y --partial --source=../config/dev" "$(mock_get_call_args "${mock_drush}" 6)"
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 7)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Development, no config, retain config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=retain
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: development"
+  assert_output_contains "Config strategy:  retain"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Development, default and dev config, retain config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=retain
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: development"
+  assert_output_contains "Config strategy:  retain"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Development, default and dev config, import content" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=import
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: development"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: import"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_contains "Performing content import."
+  assert_equal "--alias-path=/etc/drush/sites sql:sync @ci.prod @self -y" "$(mock_get_call_args "${mock_drush}" 3)"
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Performing config import."
+  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 6)"
+  assert_output_contains "Performing development config import on non-production site."
+  assert_equal "config:import -y --partial --source=../config/dev" "$(mock_get_call_args "${mock_drush}" 7)"
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 8)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Development, no config, not installed" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Failed" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: development"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  assert_output_contains "Drupal is not installed or not operational."
+  assert_equal "--alias-path=/etc/drush/sites sql:sync @ci.prod @self -y" "$(mock_get_call_args "${mock_drush}" 3)"
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 6)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+################################################################################
+#                                  LOCAL                                       #
+################################################################################
+
+@test "Local, no config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=local
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: local"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Local, default and dev config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=local
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: local"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_contains "Performing config import."
+  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_output_contains "Performing development config import on non-production site."
+  assert_equal "config:import -y --partial --source=../config/dev" "$(mock_get_call_args "${mock_drush}" 6)"
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 7)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Local, no config, retain config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=local
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=retain
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: local"
+  assert_output_contains "Config strategy:  retain"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Local, default and dev config, retain config" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=local
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=retain
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: local"
+  assert_output_contains "Config strategy:  retain"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 5)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Local, default and dev config, import content" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=local
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=import
+  export APP
+
+  fixture_config "$APP/config/default" 3
+  fixture_config "$APP/config/dev" 2
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: local"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: import"
+  assert_output_contains "There are 3 config yaml files, and 2 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_equal "updatedb -y" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "cache:rebuild" "$(mock_get_call_args "${mock_drush}" 4)"
+
+  assert_output_contains "Performing config import."
+  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_output_contains "Performing development config import on non-production site."
+  assert_equal "config:import -y --partial --source=../config/dev" "$(mock_get_call_args "${mock_drush}" 6)"
+
+  assert_output_contains "Enable stage_file_proxy in non-prod environments."
+  assert_equal "pm:enable stage_file_proxy -y" "$(mock_get_call_args "${mock_drush}" 7)"
+
+  assert_output_contains "Finished running govcms-deploy."
+}
+
+@test "Local, no config, not installed" {
+  APP="$TEST_APP_DIR"
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Failed" 2
+  mock_set_side_effect "${mock_drush}" "mkdir -p $APP/web/sites/default/files/private/backups && touch $APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" 3
+
+  # Remove any values set in the current environment.
+  export LAGOON_ENVIRONMENT_TYPE=local
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export APP
+
+  assert_dir_not_exists "$APP/web/sites/default/files/private/tmp"
+
+  run "$CUR_DIR"/scripts/govcms-deploy
+  assert_success
+
+  assert_output_contains "Running govcms-deploy"
+  assert_output_contains "Environment type: local"
+  assert_output_contains "Config strategy:  import"
+  assert_output_contains "Content strategy: retain"
+  assert_output_contains "There are 0 config yaml files, and 0 dev yaml files."
+
+  assert_dir_exists "$APP/web/sites/default/files/private/tmp"
+
+  # Bootstrap.
+  assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  # Database backup.
+  assert_output_not_contains "Making a database backup."
+
+  assert_output_contains "Drupal is not installed or not operational."
+  assert_output_contains  "Drupal is not installed locally, try ahoy install"
+
+  # Common deploy.
+  assert_output_not_contains "Performing content import."
+
+  assert_output_not_contains "Performing config import."
+  assert_output_not_contains "Performing development config import on non-production site."
+  assert_output_not_contains "Enable stage_file_proxy in non-prod environments."
+
+  assert_output_contains "Finished running govcms-deploy."
+}


### PR DESCRIPTION
- Added bats tests for `govcms-deploy` script with different input parameters:
```
    1. Defaults, no config
    2. Defaults, no config, not installed
    3. Production, no config
    4. Production, default and dev config
    5. Production, no config, retain config
    6. Production, default and dev config, retain config
    7. Production, default and dev config, import content
    8. Production, no config, not installed
    9. Development, no config
    10. Development, default and dev config
    11. Development, no config, retain config
    12. Development, default and dev config, retain config
    13. Development, default and dev config, import content
    14. Development, no config, not installed
    15. Local, no config
    16. Local, default and dev config
    17. Local, no config, retain config
    18. Local, default and dev config, retain config
    19. Local, default and dev config, import content
    20. Local, no config, not installed
```
- Updated script to support relative `APP` dir - required for testing.

Please note that these tests will be driving other tests for chunked scripts, so it is important to get them merged before any further changes to any of the scripts. 
Also, the `govcms-deploy` needs to be kept in the repo for the time being as there are outdated projects that may still use it.