### PR TITLE
[GOVCMSD8-556] Add support for DB replica when performing DB synchronisation.

### DIFF
--- a/scripts/deploy/govcms-db-sync
+++ b/scripts/deploy/govcms-db-sync
@@ -40,7 +40,7 @@ elif [ "$GOVCMS_DEPLOY_WORKFLOW_CONTENT" != "import" ]; then
 fi
 
 echo "[info]: Preparing database sync"
-drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" sql-sync @"$GOVCMS_SITE_ALIAS" @self -y
+drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" sql:sync @"$GOVCMS_SITE_ALIAS" @self -y
 # @todo: Add sanitisation?
 
 echo "[success]: Completed successfully."

--- a/scripts/deploy/govcms-db-sync
+++ b/scripts/deploy/govcms-db-sync
@@ -20,29 +20,26 @@ if [ "$LAGOON_ENVIRONMENT_TYPE" = "production" ]; then
   exit 0
 fi
 
+echo "[info]: Environment type: $LAGOON_ENVIRONMENT_TYPE"
+echo "[info]: Content strategy: $GOVCMS_DEPLOY_WORKFLOW_CONTENT"
+echo "[info]: Site alias:       $GOVCMS_SITE_ALIAS"
+echo "[info]: Alias path:       $GOVCMS_SITE_ALIAS_PATH"
+
 echo "[info]: Check that the site can be bootstrapped."
-echo "[info]: Alias path $GOVCMS_SITE_ALIAS_PATH"
-echo "[info]: Site alias $GOVCMS_SITE_ALIAS"
 
 if ! drush status --fields=bootstrap | grep -q "Successful"; then
   # This will ensure that the database is synchronised on the first deploy
-  # of an environment in lagoon.
+  # of an environment in Lagoon.
   echo "[info]: Site could not be bootstrapped... syncing."
-  drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" sql-sync @"$GOVCMS_SITE_ALIAS" @self -y
-  exit 0
-fi
-
-if [ "$GOVCMS_DEPLOY_WORKFLOW_CONTENT" != "import" ]; then
-  # Allow per environment overrides for the synchronisation flow, if the site
+elif [ "$GOVCMS_DEPLOY_WORKFLOW_CONTENT" != "import" ]; then
+  # Allow per environment overrides for the synchronisation flow: if the site
   # has bootstrapped but the environment is not set to "import" for the workflow
   # then we will not synchronise the database.
-  echo "[skip]: Site can be bootstrapped and the workflow is not set to import."
+  echo "[skip]: Site can be bootstrapped and the content workflow is not set to \"import\"."
   exit 0
 fi
 
-echo "[info]: Environment type: $LAGOON_ENVIRONMENT_TYPE"
 echo "[info]: Preparing database sync"
-
 drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" sql-sync @"$GOVCMS_SITE_ALIAS" @self -y
 # @todo: Add sanitisation?
 

--- a/scripts/deploy/govcms-db-sync
+++ b/scripts/deploy/govcms-db-sync
@@ -12,6 +12,7 @@ LAGOON_ENVIRONMENT_TYPE=${LAGOON_ENVIRONMENT_TYPE:-production}
 GOVCMS_DEPLOY_WORKFLOW_CONTENT=${GOVCMS_DEPLOY_WORKFLOW_CONTENT:-retain}
 GOVCMS_SITE_ALIAS=${GOVCMS_SITE_ALIAS:-govcms.prod}
 GOVCMS_SITE_ALIAS_PATH=${GOVCMS_SITE_ALIAS_PATH:-/etc/drush/sites}
+MARIADB_READREPLICA_HOSTS=${MARIADB_READREPLICA_HOSTS:-}
 
 echo "GovCMS Deploy :: Database synchronisation"
 
@@ -40,7 +41,17 @@ elif [ "$GOVCMS_DEPLOY_WORKFLOW_CONTENT" != "import" ]; then
 fi
 
 echo "[info]: Preparing database sync"
-drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" sql:sync @"$GOVCMS_SITE_ALIAS" @self -y
+
+# Database options to configure the remote to use the read replica when
+# performing read operations.
+sync_opts=""
+if [ -n "$MARIADB_READREPLICA_HOSTS" ] && tables=$(drush @"$GOVCMS_SITE_ALIAS" sqlq 'show tables;' --database=read 2> /dev/null) && [ -n "$tables" ]; then
+  echo "[info]: Replica is available, using for database operations."
+  sync_opts="--source-database=read"
+fi
+
+# shellcheck disable=SC2086
+drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" $sync_opts sql:sync @"$GOVCMS_SITE_ALIAS" @self -y
 # @todo: Add sanitisation?
 
 echo "[success]: Completed successfully."

--- a/scripts/govcms-deploy
+++ b/scripts/govcms-deploy
@@ -10,6 +10,8 @@ LAGOON_ENVIRONMENT_TYPE=${LAGOON_ENVIRONMENT_TYPE:-production}
 GOVCMS_DEPLOY_WORKFLOW_CONFIG=${GOVCMS_DEPLOY_WORKFLOW_CONFIG:-import}
 # Determine the content strategy `import` vs `retain`.
 GOVCMS_DEPLOY_WORKFLOW_CONTENT=${GOVCMS_DEPLOY_WORKFLOW_CONTENT:-retain}
+# Space-separated list of Db replica hosts.
+MARIADB_READREPLICA_HOSTS="${MARIADB_READREPLICA_HOSTS:-}"
 # The location of the application directory.
 APP="${APP:-/app}"
 
@@ -32,12 +34,31 @@ mkdir -p "$APP/web/sites/default/files/private/tmp"
 
 drush core:status
 
+# Database options to configure the remote to use the read replica when
+# performing read operations.
+sync_opts=""
+dump_opts=""
+read_replica_enabled () {
+  if [[ -z "$MARIADB_READREPLICA_HOSTS" ]]; then
+    return
+  fi
+
+  if tables=$(drush @ci.prod sqlq 'show tables;' --database=read 2> /dev/null) && [ -n "$tables" ]; then
+    echo "Replica is available, using for database operations."
+    sync_opts="--source-database=read"
+    # @todo: Enable below once Drush 9 has support for removed --database option.
+    # https://github.com/drush-ops/drush/issues/4274
+    # dump_opts="--database=read"
+  fi
+}
+
 # Database updates, cache rebuild, optional config imports.
 common_deploy () {
 
   if [[ "$LAGOON_ENVIRONMENT_TYPE" = "development" && "$GOVCMS_DEPLOY_WORKFLOW_CONTENT" = "import" ]]; then
     echo "Performing content import."
-    drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self -y
+    # shellcheck disable=SC2086
+    drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self $sync_opts -y
   fi
 
   drush updatedb -y
@@ -60,11 +81,14 @@ common_deploy () {
 
 }
 
+read_replica_enabled
+
 if [[ "$LAGOON_ENVIRONMENT_TYPE" = "production" ]]; then
 
   if drush status --fields=bootstrap | grep -q "Successful"; then
     echo "Making a database backup."
-    mkdir -p "$APP/web/sites/default/files/private/backups/" && drush sql:dump --gzip --result-file="$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql"
+    # shellcheck disable=SC2086
+    mkdir -p "$APP/web/sites/default/files/private/backups/" && drush sql:dump $dump_opts --gzip --result-file="$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql"
     common_deploy
   else
     echo "Drupal is not installed or not operational."
@@ -80,7 +104,8 @@ else
     else
       # In a non-functioning development site, import the database from production before running import.
       # Note, this would destroy data in a dev site that was just broken temporarily. Review?
-      drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self -y
+      # shellcheck disable=SC2086
+      drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self $sync_opts -y
       common_deploy
     fi
   else

--- a/tests/bats/deploy/govcms-db-sync.bats
+++ b/tests/bats/deploy/govcms-db-sync.bats
@@ -95,7 +95,7 @@ load ../_helpers_govcms
   assert_output_contains "[info]: Site could not be bootstrapped... syncing."
 
   assert_output_contains "[info]: Preparing database sync"
-  assert_equal "--alias-path=/etc/drush/sites sql-sync @govcms.prod @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "--alias-path=/etc/drush/sites sql:sync @govcms.prod @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
 
   assert_output_contains "[success]: Completed successfully."
   assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
@@ -123,7 +123,7 @@ load ../_helpers_govcms
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 1)"
 
   assert_output_contains "[info]: Preparing database sync"
-  assert_equal "--alias-path=/etc/drush/othersites sql-sync @govcms.override @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "--alias-path=/etc/drush/othersites sql:sync @govcms.override @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
 
   assert_output_contains "[success]: Completed successfully."
   assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
@@ -151,7 +151,7 @@ load ../_helpers_govcms
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 1)"
 
   assert_output_contains "[info]: Preparing database sync"
-  assert_equal "--alias-path=/etc/drush/sites sql-sync @govcms.prod @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "--alias-path=/etc/drush/sites sql:sync @govcms.prod @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
 
   assert_output_contains "[success]: Completed successfully."
   assert_equal 2 "$(mock_get_call_num "${mock_drush}")"

--- a/tests/bats/deploy/govcms-db-sync.bats
+++ b/tests/bats/deploy/govcms-db-sync.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2002,SC2031,SC2030
+
+load ../_helpers_govcms
+
+################################################################################
+#                               DEFAULTS                                       #
+################################################################################
+
+@test "Database sync: defaults" {
+  mock_drush=$(mock_command "drush")
+
+  export LAGOON_ENVIRONMENT_TYPE=
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export GOVCMS_SITE_ALIAS=
+  export GOVCMS_SITE_ALIAS_PATH=
+
+  run scripts/deploy/govcms-db-sync >&3
+
+  assert_output_contains "GovCMS Deploy :: Database synchronisation"
+
+  assert_output_contains "[skip]: Production environment can't be synced."
+  assert_equal 0 "$(mock_get_call_num "${mock_drush}")"
+}
+
+################################################################################
+#                               PRODUCTION                                     #
+################################################################################
+
+@test "Database sync: production" {
+  mock_drush=$(mock_command "drush")
+
+  export LAGOON_ENVIRONMENT_TYPE=production
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export GOVCMS_SITE_ALIAS=
+  export GOVCMS_SITE_ALIAS_PATH=
+
+  run scripts/deploy/govcms-db-sync >&3
+
+  assert_output_contains "GovCMS Deploy :: Database synchronisation"
+
+  assert_output_contains "[skip]: Production environment can't be synced."
+  assert_equal 0 "$(mock_get_call_num "${mock_drush}")"
+}
+
+################################################################################
+#                               DEVELOPMENT                                    #
+################################################################################
+
+@test "Database sync: development" {
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 1
+
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=
+  export GOVCMS_SITE_ALIAS=
+  export GOVCMS_SITE_ALIAS_PATH=
+
+  run scripts/deploy/govcms-db-sync >&3
+
+  assert_output_contains "GovCMS Deploy :: Database synchronisation"
+
+  assert_output_contains "[info]: Environment type: development"
+  assert_output_contains "[info]: Content strategy: retain"
+  assert_output_contains "[info]: Site alias:       govcms.prod"
+  assert_output_contains "[info]: Alias path:       /etc/drush/sites"
+
+  assert_output_contains "[info]: Check that the site can be bootstrapped."
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 1)"
+
+  assert_output_contains "[skip]: Site can be bootstrapped and the content workflow is not set to \"import\"."
+  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+}
+
+@test "Database sync: development, no existing site" {
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Failed" 1
+
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=import
+  export GOVCMS_SITE_ALIAS=
+  export GOVCMS_SITE_ALIAS_PATH=
+
+  run scripts/deploy/govcms-db-sync >&3
+
+  assert_output_contains "GovCMS Deploy :: Database synchronisation"
+
+  assert_output_contains "[info]: Environment type: development"
+  assert_output_contains "[info]: Content strategy: import"
+  assert_output_contains "[info]: Site alias:       govcms.prod"
+  assert_output_contains "[info]: Alias path:       /etc/drush/sites"
+
+  assert_output_contains "[info]: Check that the site can be bootstrapped."
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 1)"
+  assert_output_contains "[info]: Site could not be bootstrapped... syncing."
+
+  assert_output_contains "[info]: Preparing database sync"
+  assert_equal "--alias-path=/etc/drush/sites sql-sync @govcms.prod @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  assert_output_contains "[success]: Completed successfully."
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
+}
+
+@test "Database sync: development, alias overrides" {
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 1
+
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=import
+  export GOVCMS_SITE_ALIAS=govcms.override
+  export GOVCMS_SITE_ALIAS_PATH=/etc/drush/othersites
+
+  run scripts/deploy/govcms-db-sync >&3
+
+  assert_output_contains "GovCMS Deploy :: Database synchronisation"
+
+  assert_output_contains "[info]: Environment type: development"
+  assert_output_contains "[info]: Content strategy: import"
+  assert_output_contains "[info]: Site alias:       govcms.override"
+  assert_output_contains "[info]: Alias path:       /etc/drush/othersites"
+
+  assert_output_contains "[info]: Check that the site can be bootstrapped."
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 1)"
+
+  assert_output_contains "[info]: Preparing database sync"
+  assert_equal "--alias-path=/etc/drush/othersites sql-sync @govcms.override @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  assert_output_contains "[success]: Completed successfully."
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
+}
+
+@test "Database sync: development, import content" {
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "Successful" 1
+
+  export LAGOON_ENVIRONMENT_TYPE=development
+  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=import
+  export GOVCMS_SITE_ALIAS=
+  export GOVCMS_SITE_ALIAS_PATH=
+
+  run scripts/deploy/govcms-db-sync >&3
+
+  assert_output_contains "GovCMS Deploy :: Database synchronisation"
+
+  assert_output_contains "[info]: Environment type: development"
+  assert_output_contains "[info]: Content strategy: import"
+  assert_output_contains "[info]: Site alias:       govcms.prod"
+  assert_output_contains "[info]: Alias path:       /etc/drush/sites"
+
+  assert_output_contains "[info]: Check that the site can be bootstrapped."
+  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 1)"
+
+  assert_output_contains "[info]: Preparing database sync"
+  assert_equal "--alias-path=/etc/drush/sites sql-sync @govcms.prod @self -y" "$(mock_get_call_args "${mock_drush}" 2)"
+
+  assert_output_contains "[success]: Completed successfully."
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
+}

--- a/tests/bats/deploy/govcms-db-update.bats
+++ b/tests/bats/deploy/govcms-db-update.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2002,SC2031,SC2030
 
 load ../_helpers_govcms
 
@@ -9,8 +10,9 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Deploy :: Update Database"
   assert_output_contains "[info]: Preparing database update."
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+
   assert_output_contains "[success]: Completed successfully."
+  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
 }
 
 @test "Update database: skip" {
@@ -22,8 +24,9 @@ load ../_helpers_govcms
   assert_output_contains "GovCMS Deploy :: Update Database"
   assert_output_contains "[skip]: Environment variable is set to skip."
   assert_output_not_contains "[info]: Preparing database update."
-  assert_equal 0 "$(mock_get_call_num "${mock_drush}")"
+
   assert_output_not_contains "[success]: Completed successfully."
+  assert_equal 0 "$(mock_get_call_num "${mock_drush}")"
 }
 
 @test "Update database: pre-deploy tasks" {
@@ -35,6 +38,7 @@ load ../_helpers_govcms
   assert_output_contains "GovCMS Deploy :: Update Database"
   assert_output_contains "[skip]: Pre-deploy updates were applied."
   assert_output_not_contains "[info]: Preparing database update."
-  assert_equal 0 "$(mock_get_call_num "${mock_drush}")"
+
   assert_output_not_contains "[success]: Completed successfully."
+  assert_equal 0 "$(mock_get_call_num "${mock_drush}")"
 }

--- a/tests/bats/settings/general.bats
+++ b/tests/bats/settings/general.bats
@@ -99,19 +99,69 @@ settings() {
 @test "Database settings are expected" {
   DB=$(
     LAGOON=true \
-    MARIADB_DATABASE=murdoch \
-    MARIADB_USERNAME=faceman \
-    MARIADB_PASSWORD=baracus \
-    MARIADB_HOST=hannibal \
+    MARIADB_DATABASE=dbname1 \
+    MARIADB_USERNAME=dbusername1 \
+    MARIADB_PASSWORD=dbpassword1 \
+    MARIADB_HOST=dbreplicahost1 \
     settings | jq -rc '.databases.default.default'
   )
 
   [ "$(echo "$DB" | jq -rc .driver)" == "mysql" ]
-  [ "$(echo "$DB" | jq -rc .database)" == "murdoch" ]
-  [ "$(echo "$DB" | jq -rc .username)" == "faceman" ]
-  [ "$(echo "$DB" | jq -rc .password)" == "baracus" ]
-  [ "$(echo "$DB" | jq -rc .host)" == "hannibal" ]
+  [ "$(echo "$DB" | jq -rc .database)" == "dbname1" ]
+  [ "$(echo "$DB" | jq -rc .username)" == "dbusername1" ]
+  [ "$(echo "$DB" | jq -rc .password)" == "dbpassword1" ]
+  [ "$(echo "$DB" | jq -rc .host)" == "dbreplicahost1" ]
   [ "$(echo "$DB" | jq -rc .port)" == "3306" ]
   [ "$(echo "$DB" | jq -rc .charset)" == "utf8mb4" ]
   [ "$(echo "$DB" | jq -rc .collation)" == "utf8mb4_general_ci" ]
+}
+
+@test "Database settings with replica enabled" {
+  DB=$(
+    LAGOON=true \
+    MARIADB_DATABASE=dbname1 \
+    MARIADB_USERNAME=dbusername1 \
+    MARIADB_PASSWORD=dbpassword1 \
+    MARIADB_HOST=dbreplicahost1 \
+    MARIADB_READREPLICA_HOSTS="dbreplicahost1 dbreplicahost2" \
+    settings | jq -rc '.databases'
+  )
+
+  [ "$(echo "$DB" | jq -rc .default.default.driver)" == "mysql" ]
+  [ "$(echo "$DB" | jq -rc .default.default.database)" == "dbname1" ]
+  [ "$(echo "$DB" | jq -rc .default.default.username)" == "dbusername1" ]
+  [ "$(echo "$DB" | jq -rc .default.default.password)" == "dbpassword1" ]
+  [ "$(echo "$DB" | jq -rc .default.default.host)" == "dbreplicahost1" ]
+  [ "$(echo "$DB" | jq -rc .default.default.port)" == "3306" ]
+  [ "$(echo "$DB" | jq -rc .default.default.charset)" == "utf8mb4" ]
+  [ "$(echo "$DB" | jq -rc .default.default.collation)" == "utf8mb4_general_ci" ]
+
+  # Standalone connection to the read replica.
+  [ "$(echo "$DB" | jq -rc .read.default.driver)" == "mysql" ]
+  [ "$(echo "$DB" | jq -rc .read.default.database)" == "dbname1" ]
+  [ "$(echo "$DB" | jq -rc .read.default.username)" == "dbusername1" ]
+  [ "$(echo "$DB" | jq -rc .read.default.password)" == "dbpassword1" ]
+  [ "$(echo "$DB" | jq -rc .read.default.host)" == "dbreplicahost1" ]
+  [ "$(echo "$DB" | jq -rc .read.default.port)" == "3306" ]
+  [ "$(echo "$DB" | jq -rc .read.default.charset)" == "utf8mb4" ]
+  [ "$(echo "$DB" | jq -rc .read.default.collation)" == "utf8mb4_general_ci" ]
+
+  # Replica support to the default database connection (2 replica hosts).
+  [ "$(echo "$DB" | jq -rc .default.replica[0].driver)" == "mysql" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[0].database)" == "dbname1" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[0].username)" == "dbusername1" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[0].password)" == "dbpassword1" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[0].host)" == "dbreplicahost1" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[0].port)" == "3306" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[0].charset)" == "utf8mb4" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[0].collation)" == "utf8mb4_general_ci" ]
+
+  [ "$(echo "$DB" | jq -rc .default.replica[1].driver)" == "mysql" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[1].database)" == "dbname1" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[1].username)" == "dbusername1" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[1].password)" == "dbpassword1" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[1].host)" == "dbreplicahost2" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[1].port)" == "3306" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[1].charset)" == "utf8mb4" ]
+  [ "$(echo "$DB" | jq -rc .default.replica[1].collation)" == "utf8mb4_general_ci" ]
 }


### PR DESCRIPTION
- Added changes from https://github.com/govCMS/govcms8lagoon/pull/83
- Added tests for `govcms-deploy`
- Added tests for chunked deploy script `scripts/deploy/govcms-db-sync`.
- Fixed `scripts/deploy/govcms-db-sync` drush commands to use Drush 9 aliases (we are already using them in `govcms-deploy`). This is to remove ambiguity in supported Drush versions.

Note that there is no support for `sql-dump` added as Drush 9 does not support `--source-database` key. See https://github.com/drush-ops/drush/issues/4274

Changes in commits are self-contained, so can be reviewed per commit to make it easy to understand.