### PR TITLE
Remove --source-database from sync task.

### DIFF
--- a/scripts/deploy/govcms-db-sync
+++ b/scripts/deploy/govcms-db-sync
@@ -42,16 +42,8 @@ fi
 
 echo "[info]: Preparing database sync"
 
-# Database options to configure the remote to use the read replica when
-# performing read operations.
-sync_opts=""
-if [ -n "$MARIADB_READREPLICA_HOSTS" ] && tables=$(drush @"$GOVCMS_SITE_ALIAS" sqlq 'show tables;' --database=read 2> /dev/null) && [ -n "$tables" ]; then
-  echo "[info]: Replica is available, using for database operations."
-  sync_opts="--source-database=read"
-fi
-
 # shellcheck disable=SC2086
-drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" $sync_opts sql:sync @"$GOVCMS_SITE_ALIAS" @self -y
+drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" sql:sync @"$GOVCMS_SITE_ALIAS" @self -y
 # @todo: Add sanitisation?
 
 echo "[success]: Completed successfully."

--- a/scripts/govcms-deploy
+++ b/scripts/govcms-deploy
@@ -83,7 +83,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" = "production" ]]; then
   if drush status --fields=bootstrap | grep -q "Successful"; then
     echo "Making a database backup."
     # shellcheck disable=SC2086
-    mkdir -p "$APP/web/sites/default/files/private/backups/" && drush sql:dump $dump_opts --gzip --result-file="$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" $dump_opts
+    mkdir -p "$APP/web/sites/default/files/private/backups/" && drush sql:dump $dump_opts --gzip --result-file="$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql"
     common_deploy
   else
     echo "Drupal is not installed or not operational."

--- a/scripts/govcms-deploy
+++ b/scripts/govcms-deploy
@@ -36,19 +36,14 @@ drush core:status
 
 # Database options to configure the remote to use the read replica when
 # performing read operations.
-sync_opts=""
 dump_opts=""
 read_replica_enabled () {
   if [[ -z "$MARIADB_READREPLICA_HOSTS" ]]; then
     return
   fi
 
-  if tables=$(drush @ci.prod sqlq 'show tables;' --database=read 2> /dev/null) && [ -n "$tables" ]; then
-    echo "Replica is available, using for database operations."
-    sync_opts="--source-database=read"
-    # @todo: Enable below once Drush 9 has support for removed --database option.
-    # https://github.com/drush-ops/drush/issues/4274
-    # dump_opts="--database=read"
+  if tables=$(drush sqlq 'show tables;' --database=read 2> /dev/null) && [ -n "$tables" ]; then
+    dump_opts="--database=read"
   fi
 }
 
@@ -58,7 +53,7 @@ common_deploy () {
   if [[ "$LAGOON_ENVIRONMENT_TYPE" = "development" && "$GOVCMS_DEPLOY_WORKFLOW_CONTENT" = "import" ]]; then
     echo "Performing content import."
     # shellcheck disable=SC2086
-    drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self $sync_opts -y
+    drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self -y
   fi
 
   drush updatedb -y
@@ -88,7 +83,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" = "production" ]]; then
   if drush status --fields=bootstrap | grep -q "Successful"; then
     echo "Making a database backup."
     # shellcheck disable=SC2086
-    mkdir -p "$APP/web/sites/default/files/private/backups/" && drush sql:dump $dump_opts --gzip --result-file="$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql"
+    mkdir -p "$APP/web/sites/default/files/private/backups/" && drush sql:dump $dump_opts --gzip --result-file="$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" $dump_opts
     common_deploy
   else
     echo "Drupal is not installed or not operational."
@@ -105,7 +100,7 @@ else
       # In a non-functioning development site, import the database from production before running import.
       # Note, this would destroy data in a dev site that was just broken temporarily. Review?
       # shellcheck disable=SC2086
-      drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self $sync_opts -y
+      drush --alias-path=/etc/drush/sites sql:sync @ci.prod @self -y
       common_deploy
     fi
   else

--- a/tests/bats/deploy/govcms-db-sync.bats
+++ b/tests/bats/deploy/govcms-db-sync.bats
@@ -162,35 +162,3 @@ load ../_helpers_govcms
   assert_output_contains "[success]: Completed successfully."
   assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 }
-
-@test "Database sync: development, import content, db replica available" {
-  mock_drush=$(mock_command "drush")
-  mock_set_output "${mock_drush}" "Successful" 1
-  mock_set_output "${mock_drush}" "table1\ntable2" 2
-
-  export LAGOON_ENVIRONMENT_TYPE=development
-  export GOVCMS_DEPLOY_WORKFLOW_CONTENT=import
-  export GOVCMS_SITE_ALIAS=
-  export GOVCMS_SITE_ALIAS_PATH=
-  export MARIADB_READREPLICA_HOSTS="dbreplicahost1 dbreplicahost2"
-
-  run scripts/deploy/govcms-db-sync >&3
-
-  assert_output_contains "GovCMS Deploy :: Database synchronisation"
-
-  assert_output_contains "[info]: Environment type: development"
-  assert_output_contains "[info]: Content strategy: import"
-  assert_output_contains "[info]: Site alias:       govcms.prod"
-  assert_output_contains "[info]: Alias path:       /etc/drush/sites"
-
-  assert_output_contains "[info]: Check that the site can be bootstrapped."
-  assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 1)"
-
-  assert_output_contains "[info]: Preparing database sync"
-  assert_equal "@govcms.prod sqlq show tables; --database=read" "$(mock_get_call_args "${mock_drush}" 2)"
-  assert_output_contains "[info]: Replica is available, using for database operations."
-  assert_equal "--alias-path=/etc/drush/sites --source-database=read sql:sync @govcms.prod @self -y" "$(mock_get_call_args "${mock_drush}" 3)"
-
-  assert_output_contains "[success]: Completed successfully."
-  assert_equal 3 "$(mock_get_call_num "${mock_drush}")"
-}

--- a/tests/bats/govcms-deploy.bats
+++ b/tests/bats/govcms-deploy.bats
@@ -142,7 +142,7 @@ load _helpers_govcms
   # Database backup.
   assert_output_contains "Making a database backup."
   assert_dir_exists "$APP/web/sites/default/files/private/backups"
-  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql --database=read" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "sql:dump --database=read --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 4)"
 
   # Common deploy.
   assert_output_not_contains "Performing content import."
@@ -503,7 +503,7 @@ load _helpers_govcms
   # Database backup.
   assert_output_contains "Making a database backup."
   assert_dir_exists "$APP/web/sites/default/files/private/backups"
-  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql --database=read" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "sql:dump --database=read --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 4)"
 
   # Common deploy.
   assert_output_not_contains "Performing content import."

--- a/tests/bats/govcms-deploy.bats
+++ b/tests/bats/govcms-deploy.bats
@@ -134,7 +134,7 @@ load _helpers_govcms
   assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
 
   # Check DB replica.
-  assert_equal "@ci.prod sqlq show tables; --database=read" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "sqlq show tables; --database=read" "$(mock_get_call_args "${mock_drush}" 2)"
 
   # Bootstrap 2.
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 3)"
@@ -142,7 +142,7 @@ load _helpers_govcms
   # Database backup.
   assert_output_contains "Making a database backup."
   assert_dir_exists "$APP/web/sites/default/files/private/backups"
-  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql --database=read" "$(mock_get_call_args "${mock_drush}" 4)"
 
   # Common deploy.
   assert_output_not_contains "Performing content import."
@@ -495,7 +495,7 @@ load _helpers_govcms
   assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
 
   # Check DB replica.
-  assert_equal "@ci.prod sqlq show tables; --database=read" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "sqlq show tables; --database=read" "$(mock_get_call_args "${mock_drush}" 2)"
 
   # Bootstrap 2.
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 3)"
@@ -503,7 +503,7 @@ load _helpers_govcms
   # Database backup.
   assert_output_contains "Making a database backup."
   assert_dir_exists "$APP/web/sites/default/files/private/backups"
-  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "sql:dump --gzip --result-file=$APP/web/sites/default/files/private/backups/pre-deploy-dump.sql --database=read" "$(mock_get_call_args "${mock_drush}" 4)"
 
   # Common deploy.
   assert_output_not_contains "Performing content import."
@@ -864,7 +864,7 @@ load _helpers_govcms
   assert_equal "core:status" "$(mock_get_call_args "${mock_drush}" 1)"
 
   # Check DB replica.
-  assert_equal "@ci.prod sqlq show tables; --database=read" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "sqlq show tables; --database=read" "$(mock_get_call_args "${mock_drush}" 2)"
 
   # Bootstrap 2.
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 3)"


### PR DESCRIPTION
- Drush 9 does not provide the option for --source-database option for the syql:sync command.

```
$ drush sql:sync @govcms.prod @self --source-database=read -y
The "--source-database" option does not exist.  
``` 