### PR TITLE
Define govcms_settings.

### DIFF
--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -9,11 +9,17 @@
  */
 
 // phpcs:disable Drupal.Classes.ClassFileName.NoMatch
-$govcms_settings = __DIR__;
 
-// Corresponding services.yml.
+// This variable may be set from settings.php. Fallback to current directory.
+// @see https://github.com/govCMS/govcms8-scaffold-paas/blob/57cddd8/web/sites/default/settings.php#L48
 // phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
-$settings['container_yamls'][] = $govcms_settings . '/all.services.yml';
+$govcms_includes = isset($govcms_includes) ? $govcms_includes : __DIR__;
+
+/**
+ * Include the corresponding *.services.yml.
+ */
+// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$settings['container_yamls'][] = $govcms_includes . '/all.services.yml';
 
 // Drupal 8 config.
 $config_directories[CONFIG_SYNC_DIRECTORY] = '../config/default';

--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -9,6 +9,7 @@
  */
 
 // phpcs:disable Drupal.Classes.ClassFileName.NoMatch
+$govcms_settings = __DIR__;
 
 // Corresponding services.yml.
 // phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/drupal/settings/development.settings.php
+++ b/drupal/settings/development.settings.php
@@ -9,9 +9,15 @@
  * Include development services yml.
  */
 
-// Corresponding services.yml.
+// See comment in all.settings.php.
 // phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
-$settings['container_yamls'][] = $govcms_settings . '/development.services.yml';
+$govcms_includes = isset($govcms_includes) ? $govcms_includes : __DIR__;
+
+/**
+ * Include the corresponding *.services.yml.
+ */
+// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$settings['container_yamls'][] = $govcms_includes . '/development.services.yml';
 
 /**
  * Show all error messages, with backtrace information.

--- a/drupal/settings/lagoon.settings.php
+++ b/drupal/settings/lagoon.settings.php
@@ -8,12 +8,15 @@
  * the platform.).
  */
 
-/**
- * Include lagoon services file.
- */
-// Corresponding services.yml.
+// See comment in all.settings.php.
 // phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
-$settings['container_yamls'][] = $govcms_settings . '/lagoon.services.yml';
+$govcms_includes = isset($govcms_includes) ? $govcms_includes : __DIR__;
+
+/**
+ * Include the corresponding *.services.yml.
+ */
+// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$settings['container_yamls'][] = $govcms_includes . '/lagoon.services.yml';
 
 $db_conf = [
   'driver' => 'mysql',

--- a/drupal/settings/production.settings.php
+++ b/drupal/settings/production.settings.php
@@ -5,13 +5,17 @@
  * Production settings. Included from settings.php.
  */
 
-/**
- * Include production.services.yml.
- */
-
-// Corresponding services.yml.
 // phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
-$settings['container_yamls'][] = $govcms_settings . '/production.services.yml';
+
+// See comment in all.settings.php.
+// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$govcms_includes = isset($govcms_includes) ? $govcms_includes : __DIR__;
+
+/**
+ * Include the corresponding *.services.yml.
+ */
+// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$settings['container_yamls'][] = $govcms_includes . '/production.services.yml';
 
 // Inject Google Analytics snippet on all production sites.
 $config['google_analytics.settings']['codesnippet']['after'] = "gtag('config', 'UA-54970022-1', {'name': 'govcms'}); gtag('govcms.send', 'pageview', {'anonymizeIp': true})";

--- a/tests/bats/govcms-vet.bats
+++ b/tests/bats/govcms-vet.bats
@@ -23,7 +23,7 @@ setup() {
 }
 
 vet() {
-  "$CUR_DIR"/scripts/govcms-vet
+  "$CUR_DIR"/scripts/govcms-vet paas develop
 }
 
 @test "User adds a custom repository [vet-001]" {

--- a/tests/bats/govcms-vet.bats
+++ b/tests/bats/govcms-vet.bats
@@ -23,7 +23,8 @@ setup() {
 }
 
 vet() {
-  "$CUR_DIR"/scripts/govcms-vet paas develop
+  flavour=$(yq read .version.yml type)
+  "$CUR_DIR"/scripts/govcms-vet "$(flavour)" develop
 }
 
 @test "User adds a custom repository [vet-001]" {

--- a/tests/bats/govcms-vet.bats
+++ b/tests/bats/govcms-vet.bats
@@ -23,8 +23,7 @@ setup() {
 }
 
 vet() {
-  flavour=$(yq read .version.yml type)
-  "$CUR_DIR"/scripts/govcms-vet "$(flavour)" develop
+  "$CUR_DIR"/scripts/govcms-vet "$(yq read .version.yml type)" develop
 }
 
 @test "User adds a custom repository [vet-001]" {


### PR DESCRIPTION
`govcms_settings` is not defined, which causes bootstrap issues.

Namely in the (unreleased) `2.0.0` PaaS scaffold `development.services.yml` cannot be loaded, and fails with
```
  You have requested a non-existent service "cache.backend.null". Did you mean one of these: "cache.backend.apcu", "cache.backend.memory", "cache.backend.php"?
```

This is because includes silently fail.