### PR TITLE
Ensure module list is comma separated.

### DIFF
--- a/scripts/deploy/govcms-enable_modules
+++ b/scripts/deploy/govcms-enable_modules
@@ -49,7 +49,7 @@ done
 
 # If the modules are not enabled - then we must enable them.
 if [[ -n "$MODULE_LIST" ]]; then
-  MODULE_LIST=$(echo "$MODULE_LIST" | awk '{$1=$1};1')
+  MODULE_LIST=$(echo "$MODULE_LIST" | awk '{$1=$1};1' | sed 's/ /, /g')
   # SC2086 expects quoted variables, we want to pass each in as a
   # separate parameter so we disable this check.
   # shellcheck disable=SC2086

--- a/tests/bats/integration.bats
+++ b/tests/bats/integration.bats
@@ -36,6 +36,7 @@ load _helpers_govcms
   composer config repositories.test path "${REPO_DIR}"
 
   # Update composer.lock to pick up the changes to repositories.
+  export COMPOSER_MEMORY_LIMIT=-1
   composer update --ignore-platform-reqs --lock
 
   # Add the repo at the checked out version.


### PR DESCRIPTION
Drush `pm:enable` expects a [comma-separated list of modules](https://drushcommands.com/drush-9x/pm/pm:enable/).