### PR TITLE
[GOVCMSD8-666] Update drupal/fast_404

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "drupal/chosen_lib": "2.6.0",
         "drupal/clamav": "1.1.0",
         "drupal/console": "^1.0.2",
-        "drupal/fast_404": "^1.0@alpha",
+        "drupal/fast_404": "^2.0@alpha",
         "drupal/lagoon_logs": "^1.0",
         "drupal/redis":"1.1.0",
         "drupal/stage_file_proxy":"1.0.0-alpha3",

--- a/tests/bats/govcms-vet.bats
+++ b/tests/bats/govcms-vet.bats
@@ -20,6 +20,7 @@ setup() {
   git --version
   git reset --hard --quiet rollback
   git clean -fd --quiet
+  rm composer.lock
 }
 
 vet() {

--- a/tests/bats/integration.bats
+++ b/tests/bats/integration.bats
@@ -35,9 +35,9 @@ load _helpers_govcms
   # Override scaffold repo path with a path to our version.
   composer config repositories.test path "${REPO_DIR}"
 
-  # Update composer.lock to pick up the changes to repositories.
+  # Generate composer.lock and validate fresh install with latest dependencies.
   export COMPOSER_MEMORY_LIMIT=-1
-  composer update --ignore-platform-reqs --lock
+  composer install --ignore-platform-reqs
 
   # Add the repo at the checked out version.
   composer require govcms/scaffold-tooling:dev-"${LATEST_DEV_VERSION}" --ignore-platform-reqs

--- a/tests/bats/integration.bats
+++ b/tests/bats/integration.bats
@@ -40,7 +40,7 @@ load _helpers_govcms
   composer install --ignore-platform-reqs
 
   # Add the repo at the checked out version.
-  composer require govcms/scaffold-tooling:dev-"${LATEST_DEV_VERSION}" --ignore-platform-reqs
+  composer require govcms/scaffold-tooling:dev-"${LATEST_DEV_VERSION}" --ignore-platform-reqs --update-with-dependencies
 
   # Assert that modified settings file was included after 'composer update'.
   assert_file_contains vendor/govcms/scaffold-tooling/drupal/settings/all.settings.php "${LATEST_COMMIT}"


### PR DESCRIPTION
Update `drupal/fast_404` since the 1.x branch is unsupported.