### PR TITLE
Loosen constraints in an attempt to move to D9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,20 +3,21 @@
     "description": "A variety of standard config, scripts and packages to support GovCMS scaffold.",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "drupal/chosen_lib": "2.6.0",
-        "drupal/clamav": "1.1.0",
-        "drupal/console": "^1.0.2",
-        "drupal/fast_404": "^1.0@alpha",
+        "drupal/chosen_lib": "~2",
+        "drupal/clamav": "~1",
+        "drupal/fast_404": "~1",
         "drupal/lagoon_logs": "^1.0",
         "drupal/redis":"1.1.0",
-        "drupal/stage_file_proxy":"1.0.0-alpha3",
-        "drush/drush": "^9.0.0",
-        "phar-io/manifest": "1.0.1",
-        "phar-io/version": "1.0.1",
+        "drupal/stage_file_proxy":"~1",
+        "drush/drush": "~9 || ~10",
+        "zaporylie/composer-drupal-optimizations": "^1.0"
+    },
+    "require-dev": {
+        "phar-io/manifest": "~1",
+        "phar-io/version": "~1",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "zaporylie/composer-drupal-optimizations": "^1.0"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
     },
     "bin": [
         "scripts/govcms-audit",


### PR DESCRIPTION
See #59 and #58 

Removed console here, obviously that may not fly

ClamAV and Fast 404 are going to be watch and wait for D9 releases.