### PR TITLE
Added core_version_requirement key.

### DIFF
--- a/drupal/modules/lagoon/govcms_lagoon/govcms_lagoon.info.yml
+++ b/drupal/modules/lagoon/govcms_lagoon/govcms_lagoon.info.yml
@@ -4,6 +4,7 @@ package: Lagoon
 
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 
 dependencies:
   - redis:redis

--- a/drupal/modules/lagoon/lagoon_search/lagoon_search.info.yml
+++ b/drupal/modules/lagoon/lagoon_search/lagoon_search.info.yml
@@ -5,6 +5,7 @@ version: 8.x-1.1
 
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 
 dependencies:
   - search_api_solr:search_api_solr


### PR DESCRIPTION
Noting we are still waiting on a 9.x release for clamav/fast_404