### PR TITLE
Ensure directories are available.

### DIFF
--- a/scripts/deploy/govcms-update_site_alias
+++ b/scripts/deploy/govcms-update_site_alias
@@ -17,7 +17,7 @@ set -euo pipefail
 echo "GovCMS Deploy :: Update site alias"
 
 # Ensure directories are available.
-mkdir -p /app/web/sites/default/files/private/{backups,tmp
+mkdir -p /app/web/sites/default/files/private/{backups,tmp}
 
 if [ ! -f /app/drush/sites/govcms.site.yml ]; then
   echo "[skip]: Site alias file does not exist."

--- a/scripts/deploy/govcms-update_site_alias
+++ b/scripts/deploy/govcms-update_site_alias
@@ -16,6 +16,9 @@ set -euo pipefail
 
 echo "GovCMS Deploy :: Update site alias"
 
+# Ensure directories are available.
+mkdir -p /app/web/sites/default/files/private/{backups,tmp
+
 if [ ! -f /app/drush/sites/govcms.site.yml ]; then
   echo "[skip]: Site alias file does not exist."
   exit 0;

--- a/scripts/deploy/govcms-update_site_alias
+++ b/scripts/deploy/govcms-update_site_alias
@@ -16,7 +16,11 @@ set -euo pipefail
 
 echo "GovCMS Deploy :: Update site alias"
 
-# Ensure directories are available.
+# When a new environment is created a new mount is provisioned. This
+# overrides the standard files directory created by the base containers.
+# Drupal doesn't create the directories and expects them to exist so
+# that it can use them. This is a stopgap fix to ensure that the files
+# directory is available for all containers.
 mkdir -p /app/web/sites/default/files/private/{backups,tmp}
 
 if [ ! -f /app/drush/sites/govcms.site.yml ]; then


### PR DESCRIPTION
This is a stopgap measure; with the scaffold update to 1.2.0 the `mkdir -p` was removed and it has not been added to a script in scaffold-tooling. This is a hotfix to restore functionality while a more permanent fix is added in an upcoming release as scaffold updates take at minimum 19 hours to complete.

### Proposed completed release

- Create a new deploy script `govcms-prepare` that can house any operations that need to be actioned prior to an environment being created
- Update the scaffold to execute the prepare script
- Rollout the update to the fleet.