### PR TITLE
Change REDIS_PORT to REDIS_SERVICE_PORT.

### DIFF
--- a/drupal/settings/lagoon.settings.php
+++ b/drupal/settings/lagoon.settings.php
@@ -77,7 +77,7 @@ $settings['varnish_version'] = 4;
 if (getenv('ENABLE_REDIS')) {
   $redis = new \Redis();
   $redis_host = getenv('REDIS_HOST') ?: 'redis';
-  $redis_port = getenv('REDIS_SERVICE_PORT') ?: '6379';
+  $redis_port = getenv('REDIS_SERVICE_PORT') ?: 6379;
   // Redis should return in < 1s so this is a maximum time
   // to ensure we don't hold the proc forever.
   $redis_timeout = getenv('REDIS_CONNECT_TIMEOUT') ?: 2;

--- a/drupal/settings/lagoon.settings.php
+++ b/drupal/settings/lagoon.settings.php
@@ -77,7 +77,7 @@ $settings['varnish_version'] = 4;
 if (getenv('ENABLE_REDIS')) {
   $redis = new \Redis();
   $redis_host = getenv('REDIS_HOST') ?: 'redis';
-  $redis_port = getenv('REDIS_PORT') ?: 6379;
+  $redis_port = getenv('REDIS_SERVICE_PORT') ?: '6379';
   // Redis should return in < 1s so this is a maximum time
   // to ensure we don't hold the proc forever.
   $redis_timeout = getenv('REDIS_CONNECT_TIMEOUT') ?: 2;


### PR DESCRIPTION
`REDIS_PORT` is incorrectly set in Lagoon/Openshift to a full TCP address of the redis host. This causes an invalid port when attempting a redis connection so this will fail and default the site to use a null backend.

https://github.com/govCMS/govcms8lagoon/blob/develop/.docker/images/govcms8/settings/settings.php#L175