### PR TITLE
Removed chosen_lib from tooling.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "drupal/chosen_lib": "2.6.0",
         "drupal/clamav": "1.1.0",
         "drupal/console": "^1.0.2",
         "drupal/fast_404": "^2.0@alpha",


### PR DESCRIPTION
The chosen library should be shipped/bundled with the distribution rather than in tooling.