### PR TITLE
Enable gc override.

### DIFF
--- a/drupal/settings/production.settings.php
+++ b/drupal/settings/production.settings.php
@@ -41,3 +41,6 @@ $config['stage_file_proxy.settings']['origin'] = FALSE;
 
 // Disable temporary file deletion (GOVCMSD8-576).
 $config['system.file']['temporary_maximum_age'] = 0;
+if (is_numeric($image_gc = getenv('GOVCMS_FILE_TEMP_MAX_AGE'))) {
+  $config['system.file']['temporary_maximum_age'] = $image_gc;
+}

--- a/drupal/settings/production.settings.php
+++ b/drupal/settings/production.settings.php
@@ -41,6 +41,6 @@ $config['stage_file_proxy.settings']['origin'] = FALSE;
 
 // Disable temporary file deletion (GOVCMSD8-576).
 $config['system.file']['temporary_maximum_age'] = 0;
-if (is_numeric($image_gc = getenv('GOVCMS_FILE_TEMP_MAX_AGE'))) {
-  $config['system.file']['temporary_maximum_age'] = $image_gc;
+if (is_numeric($file_gc = getenv('GOVCMS_FILE_TEMP_MAX_AGE'))) {
+  $config['system.file']['temporary_maximum_age'] = $file_gc;
 }


### PR DESCRIPTION
- Adds the `GOVCMS_FILE_TEMP_MAX_AGE` environment variable to allow support agents to enable temporary file GC.