### PR TITLE
Ensure cache-rebuild for first-time 9.x upgrade.

### DIFF
--- a/scripts/deploy/govcms-db-update
+++ b/scripts/deploy/govcms-db-update
@@ -9,6 +9,7 @@ set -euo pipefail
 LAGOON_ENVIRONMENT_TYPE=${LAGOON_ENVIRONMENT_TYPE:-production}
 GOVCMS_DEPLOY_UPDB=${GOVCMS_DEPLOY_UPDB:-true}
 GOVCMS_DEPLOY_PRE_UPDB=${GOVCMS_DEPLOY_PRE_UPDB:-false}
+GOVCMS_CACHE_REBUILD_PRE_UPDB=${GOVCMS_CACHE_REBUILD_PRE_UPDB:-false}
 
 echo "GovCMS Deploy :: Update Database"
 
@@ -28,6 +29,22 @@ fi
 if ! drush status --fields=bootstrap | grep -q "Successful"; then
   echo '[skip]: Site is not available.'
   exit 0
+fi
+
+# Drupal 9 upgrade support.
+# First time an environment updates from 8.x to 9.x
+if drush status --format=json | grep drupal-version | grep -q "\"9"; then
+  echo "[info]: Detected Drupal 9 codebase."
+  if drush pm-list --core --format=json | grep -q "\"8"; then
+    echo "[info]: Detected Drupal 8 core database schema."
+    echo "[info]: Running cache-rebuild prior to database update."
+    drush cr
+  fi
+fi
+
+if [ "$GOVCMS_CACHE_REBUILD_PRE_UPDB" != "false" ]; then
+  # Allow forced cache-rebuild prior to database updates.
+  drush cr
 fi
 
 echo "[info]: Preparing database update."

--- a/tests/bats/deploy/govcms-db-update.bats
+++ b/tests/bats/deploy/govcms-db-update.bats
@@ -13,7 +13,7 @@ load ../_helpers_govcms
   assert_output_contains "[info]: Preparing database update."
 
   assert_output_contains "[success]: Completed successfully."
-  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 3 "$(mock_get_call_num "${mock_drush}")"
 }
 
 @test "Update database: skip" {


### PR DESCRIPTION
```
GovCMS Deploy :: Update Database
[info]: Detected Drupal 9 codebase.
[info]: Detected Drupal 8 core database schema.
[info]: Running cache-rebuild prior to database update.
 [success] Cache rebuild complete.
```

8.x => 9.x upgrade pathway requires a cache-rebuild before database updates.

Also adds a more generic env var `GOVCMS_CACHE_REBUILD_PRE_UPDB` for future use