### PR TITLE
Moved to more controlled dump and sync for non-prod environments.

### DIFF
--- a/drupal/settings/lagoon.settings.php
+++ b/drupal/settings/lagoon.settings.php
@@ -48,8 +48,6 @@ if (getenv('MARIADB_READREPLICA_HOSTS')) {
     foreach ($replica_hosts as $replica_host) {
       // Add replica support to the default database connection. This allows
       // services to use the database.replica service for particular operations.
-      // @TODO: Lagoon should expose MARAIDB replica hosts as an array so we can
-      // scale the replicas horizontally.
       $databases['default']['replica'][] = array_merge($db_conf, [
         'host' => $replica_host,
       ]);

--- a/scripts/deploy/govcms-db-sync
+++ b/scripts/deploy/govcms-db-sync
@@ -13,6 +13,7 @@ GOVCMS_DEPLOY_WORKFLOW_CONTENT=${GOVCMS_DEPLOY_WORKFLOW_CONTENT:-retain}
 GOVCMS_SITE_ALIAS=${GOVCMS_SITE_ALIAS:-govcms.prod}
 GOVCMS_SITE_ALIAS_PATH=${GOVCMS_SITE_ALIAS_PATH:-/app/drush/sites}
 MARIADB_READREPLICA_HOSTS=${MARIADB_READREPLICA_HOSTS:-}
+GOVCMS_TEST_CANARY=${GOVCMS_TEST_CANARY:-FALSE}
 
 echo "GovCMS Deploy :: Database synchronisation"
 
@@ -28,7 +29,9 @@ echo "[info]: Alias path:       $GOVCMS_SITE_ALIAS_PATH"
 
 echo "[info]: Check that the site can be bootstrapped."
 
-if ! drush status --fields=bootstrap | grep -q "Successful"; then
+if [[ "$GOVCMS_TEST_CANARY" = TRUE ]]; then
+  echo "[info]: Canary site... syncing."
+elif ! drush status --fields=bootstrap | grep -q "Successful"; then
   # This will ensure that the database is synchronised on the first deploy
   # of an environment in Lagoon.
   echo "[info]: Site could not be bootstrapped... syncing."
@@ -43,7 +46,10 @@ fi
 echo "[info]: Preparing database sync"
 
 # shellcheck disable=SC2086
-drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" sql:sync @"$GOVCMS_SITE_ALIAS" @self -y
+drush --alias-path="$GOVCMS_SITE_ALIAS_PATH" @"$GOVCMS_SITE_ALIAS" sql:dump --gzip --result-file=/tmp/sync.sql -y
+drush rsync --alias-path="$GOVCMS_SITE_ALIAS_PATH" @"$GOVCMS_SITE_ALIAS":/tmp/sync.sql.gz /tmp/ -y
+gunzip < /tmp/sync.sql.gz | drush sqlc
+rm /tmp/sync.sql.gz
 # @todo: Add sanitisation?
 
 echo "[success]: Completed successfully."

--- a/scripts/govcms-deploy
+++ b/scripts/govcms-deploy
@@ -53,7 +53,10 @@ common_deploy () {
   if [[ "$LAGOON_ENVIRONMENT_TYPE" = "development" && "$GOVCMS_DEPLOY_WORKFLOW_CONTENT" = "import" ]]; then
     echo "Performing content import."
     # shellcheck disable=SC2086
-    drush --alias-path=/app/drush/sites sql:sync @govcms.prod @self -y
+    drush --alias-path=/app/drush/sites @govcms.prod sql:dump --gzip --result-file=/tmp/sync.sql -y
+    drush rsync --alias-path=/app/drush/sites @govcms.prod:/tmp/sync.sql.gz /tmp/ -y
+    gunzip < /tmp/sync.sql.gz | drush sqlc
+    rm /tmp/sync.sql.gz
   fi
 
   drush updatedb -y


### PR DESCRIPTION
* Prevents drush attempting to import a gz file via sqlc
* Ensures database sync always happens on canary environments