### PR TITLE
[GOVCMS-5033] Removed legacy solr configuration.

### DIFF
--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -125,8 +125,6 @@ if (defined('STDIN') || in_array(PHP_SAPI, ['cli', 'cli-server'])) {
   }
 }
 
-// Enforce correct solr server configuration (GOVCMS-4634).
-// Fix for 8.5.0 and the solr upgrade.
 $config['search_api.server.lagoon_solr']['backend_config']['connector_config']['path'] = '/';
 $config['search_api.server.lagoon_solr']['backend_config']['connector_config']['core'] = 'drupal';
 

--- a/drupal/settings/development.settings.php
+++ b/drupal/settings/development.settings.php
@@ -49,10 +49,19 @@ $config['system.performance']['js']['preprocess'] = FALSE;
 $settings['cache']['bins']['render'] = 'cache.backend.null';
 $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
 
-// Stage file proxy.
+/**
+ * Configure stage file proxy.
+ */
 if (getenv('STAGE_FILE_PROXY_URL')) {
   $config['stage_file_proxy.settings']['origin'] = getenv('STAGE_FILE_PROXY_URL');
 }
 elseif (getenv('LAGOON_PROJECT')) {
   $config['stage_file_proxy.settings']['origin'] = 'https://nginx-' . getenv('LAGOON_PROJECT') . '-master.govcms.amazee.io';
 }
+
+/**
+ * Configure Environment indicator.
+ */
+$config['environment_indicator.indicator']['bg_color'] = '#006600';
+$config['environment_indicator.indicator']['fg_color'] = '#FFFFFF';
+$config['environment_indicator.indicator']['name'] = 'Non-production';

--- a/drupal/settings/lagoon.settings.php
+++ b/drupal/settings/lagoon.settings.php
@@ -8,6 +8,8 @@
  * the platform.).
  */
 
+use Drupal\Core\Installer\InstallerKernel;
+
 // phpcs:disable Drupal.Classes.UseGlobalClass.RedundantUseStatement
 
 // See comment in all.settings.php.
@@ -55,10 +57,6 @@ if (getenv('MARIADB_READREPLICA_HOSTS')) {
   }
 }
 
-// Lagoon Solr connection.
-$config['search_api.server']['backend_config']['connector_config']['host'] = getenv('SOLR_HOST') ?: 'solr';
-$config['search_api.server']['backend_config']['connector_config']['path'] = '/solr/' . getenv('SOLR_CORE') ?: 'drupal';
-
 // Lagoon Varnish & reverse proxy settings.
 $varnish_hosts = explode(',', getenv('VARNISH_HOSTS') ?: 'varnish');
 array_walk($varnish_hosts, function (&$value, $key) {
@@ -81,7 +79,7 @@ if (getenv('ENABLE_REDIS')) {
   $redis_timeout = getenv('REDIS_CONNECT_TIMEOUT') ?: 2;
 
   try {
-    if (drupal_installation_attempted()) {
+    if (InstallerKernel::installationAttempted()) {
       // Do not set the cache during installations of Drupal.
       throw new \Exception('Drupal installation underway.');
     }

--- a/drupal/settings/production.settings.php
+++ b/drupal/settings/production.settings.php
@@ -39,6 +39,11 @@ $config['system.performance']['js']['preprocess'] = 1;
 // even on production.
 $config['stage_file_proxy.settings']['origin'] = FALSE;
 
+// Configure Environment indicator.
+$config['environment_indicator.indicator']['bg_color'] = '#AF110E';
+$config['environment_indicator.indicator']['fg_color'] = '#FFFFFF';
+$config['environment_indicator.indicator']['name'] = 'Production';
+
 // Disable temporary file deletion (GOVCMSD8-576).
 $config['system.file']['temporary_maximum_age'] = 0;
 if (is_numeric($file_gc = getenv('GOVCMS_FILE_TEMP_MAX_AGE'))) {

--- a/tests/bats/settings/edge.bats
+++ b/tests/bats/settings/edge.bats
@@ -3,21 +3,31 @@
 load ../_helpers_govcms
 
 setup() {
-  if [ ! -f "/tmp/bats/settings.php" ]; then
+  if [ ! -f "/tmp/bats/all.settings.php" ]; then
     mkdir -p /tmp/bats
-    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/simesy/govcms8-scaffold/paas-saas-mash-up/web/sites/default/settings.php)
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/all.settings.php)
+  fi
+
+  if [ ! -f "/tmp/bats/lagoon.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/lagoon.settings.php)
   fi
 }
 
-settings() {
-  JSON=$(./tests/drupal-settings-to-json.php)
+all_settings() {
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/all.settings.php)
+  echo "$JSON"
+}
+
+lagoon_settings() {
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/lagoon.settings.php)
   echo "$JSON"
 }
 
 @test "Akamai friendly caching" {
   SETTINGS=$(
     LAGOON=true \
-    settings | jq -rc .settings
+    all_settings | jq -rc .settings
   )
   [ "$(echo "$SETTINGS" | jq .page_cache_invoke_hooks)" == "true" ]
   [ "$(echo "$SETTINGS" | jq .redirect_page_cache)" == "true" ]
@@ -29,7 +39,7 @@ settings() {
     VARNISH_CONTROL_PORT="4041" \
     VARNISH_HOSTS="chip,dale" \
     VARNISH_SECRET=shhhh \
-    settings | jq -rc .settings
+    lagoon_settings | jq -rc .settings
   )
 
   [ "$(echo "$SETTINGS" | jq -rc .varnish_control_terminal)" == 'chip:4041 dale:4041' ]

--- a/tests/bats/settings/environments.bats
+++ b/tests/bats/settings/environments.bats
@@ -8,6 +8,26 @@ setup() {
     (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/settings.php)
     sed -i.bak 's/govcms_includes =.*/govcms_includes = "\/tmp\/bats";/g' /tmp/bats/settings.php
   fi
+
+  if [ ! -f "/tmp/bats/all.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/all.settings.php)
+  fi
+
+  if [ ! -f "/tmp/bats/development.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/development.settings.php)
+  fi
+
+  if [ ! -f "/tmp/bats/production.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/production.settings.php)
+  fi
+
+  if [ ! -f "/tmp/bats/lagoon.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/lagoon.settings.php)
+  fi
 }
 
 settings() {

--- a/tests/bats/settings/environments.bats
+++ b/tests/bats/settings/environments.bats
@@ -5,20 +5,21 @@ load ../_helpers_govcms
 setup() {
   if [ ! -f "/tmp/bats/settings.php" ]; then
     mkdir -p /tmp/bats
-    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/simesy/govcms8-scaffold/paas-saas-mash-up/web/sites/default/settings.php)
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/settings.php)
+    sed -i.bak 's/govcms_includes =.*/govcms_includes = "\/tmp\/bats";/g' /tmp/bats/settings.php
   fi
 }
 
 settings() {
-  JSON=$(./tests/drupal-settings-to-json.php)
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/settings.php)
   echo "$JSON"
 }
 
 @test "Correct includes in dev mode (not lagoon)" {
   FILES=$(
     unset LAGOON
-    DEV_MODE=true \
-    LAGOON_ENVIRONMENT_TYPE=production \
+    DEV_MODE='true' \
+    LAGOON_ENVIRONMENT_TYPE=development \
     settings | jq .included_files
   )
 
@@ -33,7 +34,7 @@ settings() {
   FILES=$(
     LAGOON=true \
     DEV_MODE=true \
-    LAGOON_ENVIRONMENT_TYPE=production \
+    LAGOON_ENVIRONMENT_TYPE=development \
     settings | jq .included_files
   )
 

--- a/tests/bats/settings/environments.bats
+++ b/tests/bats/settings/environments.bats
@@ -47,6 +47,7 @@ settings() {
 @test "Correct includes in production mode (not lagoon)" {
   FILES=$(
     unset LAGOON
+    unset DEV_MODE
     LAGOON_ENVIRONMENT_TYPE=production \
     settings | jq .included_files
   )
@@ -58,6 +59,7 @@ settings() {
 
 @test "Correct includes in production mode (lagoon image)" {
   FILES=$(
+    unset DEV_MODE
     LAGOON_ENVIRONMENT_TYPE=production \
     LAGOON=true \
     settings | jq .included_files
@@ -83,6 +85,7 @@ settings() {
 
 @test "Correct yamls production mode" {
   YAMLS=$(
+    unset DEV_MODE
     LAGOON=true \
     LAGOON_ENVIRONMENT_TYPE=production \
     settings | jq -rc .settings.container_yamls

--- a/tests/bats/settings/general.bats
+++ b/tests/bats/settings/general.bats
@@ -123,7 +123,6 @@ lagoon_settings() {
     all_settings | jq -rc '.config | "\(.["search_api.server.lagoon_solr"])"'
   )
 
-  echo $SOLR
   [ "$(echo "$SOLR" | jq -rc .backend_config.connector_config.path)" == '/' ]
   [ "$(echo "$SOLR" | jq -rc .backend_config.connector_config.core)" == 'drupal' ]
 }

--- a/tests/bats/settings/general.bats
+++ b/tests/bats/settings/general.bats
@@ -3,34 +3,64 @@
 load ../_helpers_govcms
 
 setup() {
-  if [ ! -f "/tmp/bats/settings.php" ]; then
+  if [ ! -f "/tmp/bats/all.settings.php" ]; then
     mkdir -p /tmp/bats
-    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/simesy/govcms8-scaffold/paas-saas-mash-up/web/sites/default/settings.php)
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/all.settings.php)
+  fi
+
+  if [ ! -f "/tmp/bats/development.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/development.settings.php)
+  fi
+
+  if [ ! -f "/tmp/bats/production.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/production.settings.php)
+  fi
+
+  if [ ! -f "/tmp/bats/lagoon.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/lagoon.settings.php)
   fi
 }
 
-settings() {
-  JSON=$(./tests/drupal-settings-to-json.php)
+all_settings() {
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/all.settings.php)
+  echo "$JSON"
+}
+
+development_settings() {
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/development.settings.php)
+  echo "$JSON"
+}
+
+production_settings() {
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/production.settings.php)
+  echo "$JSON"
+}
+
+lagoon_settings() {
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/lagoon.settings.php)
   echo "$JSON"
 }
 
 @test "Shield settings allows CLI" {
-  OUT=$(settings | jq -cr '.config | "\(.["shield.settings"]["allow_cli"])"')
+  OUT=$(all_settings | jq -cr '.config | "\(.["shield.settings"]["allow_cli"])"')
   [ "$OUT" == "true" ]
 }
 
 @test "File path is correct" {
-  OUT=$(settings | jq -cr .settings.file_public_path)
+  OUT=$(all_settings | jq -cr .settings.file_public_path)
   [ "$OUT" == "sites/default/files" ]
 }
 
 @test "Private file path is correct" {
-  OUT=$(settings | jq -cr .settings.file_private_path)
+  OUT=$(all_settings | jq -cr .settings.file_private_path)
   [ "$OUT" == "sites/default/files/private" ]
 }
 
 @test "Tmp file path is correct" {
-  OUT=$(settings | jq -cr .settings.file_temp_path)
+  OUT=$(all_settings | jq -cr .settings.file_temp_path)
   [ "$OUT" == "sites/default/files/private/tmp" ]
 }
 
@@ -41,11 +71,11 @@ settings() {
 @test "GA disabled for dev" {
   DEV1=$(
     LAGOON_ENVIRONMENT_TYPE=development \
-    settings | jq -rc '.config | "\(.["google_analytics.settings"])"'
+    development_settings | jq -rc '.config | "\(.["google_analytics.settings"])"'
   )
   DEV2=$(
     DEV_MODE=true \
-    settings | jq -rc '.config | "\(.["google_analytics.settings"])"'
+    development_settings | jq -rc '.config | "\(.["google_analytics.settings"])"'
   )
   [ "$(echo "$DEV1" | jq -rc .account)" == "UA-XXXXXXXX-YY" ]
   [ "$(echo "$DEV2" | jq -rc .account)" == "UA-XXXXXXXX-YY" ]
@@ -54,7 +84,7 @@ settings() {
 @test "GA settings for prod" {
   SNIPPET=$(
     LAGOON_ENVIRONMENT_TYPE=production \
-    settings | jq -rc '.config | "\(.["google_analytics.settings"]["codesnippet"]["after"])"'
+    production_settings | jq -rc '.config | "\(.["google_analytics.settings"]["codesnippet"]["after"])"'
   )
   [[ "$SNIPPET" == *"gtag('config', 'UA-54970022-1', {'name': 'govcms'})"* ]]
   [[ "$SNIPPET" == *"gtag('govcms.send', 'pageview', {'anonymizeIp': true})"* ]]
@@ -63,7 +93,7 @@ settings() {
 @test "Stage file proxy settings for prod" {
   SFP=$(
     LAGOON_ENVIRONMENT_TYPE=production \
-    settings | jq -rc '.config | "\(.["stage_file_proxy.settings"])"'
+    production_settings | jq -rc '.config | "\(.["stage_file_proxy.settings"])"'
   )
   [ "$(echo "$SFP" | jq -rc .origin)" == "false" ]
 }
@@ -72,13 +102,13 @@ settings() {
   SFP_DEFAULT=$(
     LAGOON_PROJECT=govcmsd8 \
     LAGOON_ENVIRONMENT_TYPE=development \
-    settings | jq -rc '.config | "\(.["stage_file_proxy.settings"])"'
+    development_settings | jq -rc '.config | "\(.["stage_file_proxy.settings"])"'
   )
   SFP_OVERRIDE=$(
     LAGOON_PROJECT=should-not-use \
     STAGE_FILE_PROXY_URL="https://www.govcms.gov.au" \
     LAGOON_ENVIRONMENT_TYPE=development \
-    settings | jq -rc '.config | "\(.["stage_file_proxy.settings"])"'
+    development_settings | jq -rc '.config | "\(.["stage_file_proxy.settings"])"'
   )
 
   [ "$(echo "$SFP_DEFAULT" | jq -rc .origin)" == "https://nginx-govcmsd8-master.govcms.amazee.io" ]
@@ -87,13 +117,15 @@ settings() {
 
 @test "Solr settings" {
   SOLR=$(
-    SOLR_HOST=labradoodle \
-    SOLR_CORE=endor \
+    SOLR_HOST=gramble \
+    SOLR_CORE=boop \
     LAGOON=true \
-    settings | jq -rc '.config | "\(.["search_api.server"])"'
+    all_settings | jq -rc '.config | "\(.["search_api.server.lagoon_solr"])"'
   )
-  [ "$(echo "$SOLR" | jq -rc .backend_config.connector_config.host)" == "labradoodle" ]
-  [ "$(echo "$SOLR" | jq -rc .backend_config.connector_config.path)" == '/solr/endor' ]
+
+  echo $SOLR
+  [ "$(echo "$SOLR" | jq -rc .backend_config.connector_config.path)" == '/' ]
+  [ "$(echo "$SOLR" | jq -rc .backend_config.connector_config.core)" == 'drupal' ]
 }
 
 @test "Database settings are expected" {
@@ -103,7 +135,7 @@ settings() {
     MARIADB_USERNAME=dbusername1 \
     MARIADB_PASSWORD=dbpassword1 \
     MARIADB_HOST=dbreplicahost1 \
-    settings | jq -rc '.databases.default.default'
+    lagoon_settings | jq -rc '.databases.default.default'
   )
 
   [ "$(echo "$DB" | jq -rc .driver)" == "mysql" ]
@@ -124,7 +156,7 @@ settings() {
     MARIADB_PASSWORD=dbpassword1 \
     MARIADB_HOST=dbreplicahost1 \
     MARIADB_READREPLICA_HOSTS="dbreplicahost1 dbreplicahost2" \
-    settings | jq -rc '.databases'
+    lagoon_settings | jq -rc '.databases'
   )
 
   [ "$(echo "$DB" | jq -rc .default.default.driver)" == "mysql" ]

--- a/tests/bats/settings/performance.bats
+++ b/tests/bats/settings/performance.bats
@@ -3,14 +3,14 @@
 load ../_helpers_govcms
 
 setup() {
-  if [ ! -f "/tmp/bats/settings.php" ]; then
+  if [ ! -f "/tmp/bats/production.settings.php" ]; then
     mkdir -p /tmp/bats
-    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/simesy/govcms8-scaffold/paas-saas-mash-up/web/sites/default/settings.php)
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/production.settings.php)
   fi
 }
 
 settings() {
-  JSON=$(./tests/drupal-settings-to-json.php)
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/production.settings.php)
   echo "$JSON"
 }
 

--- a/tests/bats/settings/security.bats
+++ b/tests/bats/settings/security.bats
@@ -5,12 +5,12 @@ load ../_helpers_govcms
 setup() {
   if [ ! -f "/tmp/bats/settings.php" ]; then
     mkdir -p /tmp/bats
-    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/simesy/govcms8-scaffold/paas-saas-mash-up/web/sites/default/settings.php)
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/all.settings.php)
   fi
 }
 
 settings() {
-  JSON=$(./tests/drupal-settings-to-json.php)
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/settings.php)
   echo "$JSON"
 }
 

--- a/tests/bats/settings/security.bats
+++ b/tests/bats/settings/security.bats
@@ -7,10 +7,20 @@ setup() {
     mkdir -p /tmp/bats
     (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/all.settings.php)
   fi
+
+  if [ ! -f "/tmp/bats/lagoon.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/lagoon.settings.php)
+  fi
 }
 
 settings() {
   JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/all.settings.php)
+  echo "$JSON"
+}
+
+lagoon_settings() {
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/lagoon.settings.php)
   echo "$JSON"
 }
 
@@ -45,7 +55,7 @@ settings() {
 @test "Clam AV settings" {
   SOLR=$(
     LAGOON=true \
-    settings | jq -rc '.config | "\(.["clamav.settings"])"'
+    lagoon_settings | jq -rc '.config | "\(.["clamav.settings"])"'
   )
   [ "$(echo "$SOLR" | jq -rc .scan_mode)" == 1 ]
   [ "$(echo "$SOLR" | jq -rc .mode_executable.executable_path)" == "/usr/bin/clamscan" ]

--- a/tests/bats/settings/security.bats
+++ b/tests/bats/settings/security.bats
@@ -3,14 +3,14 @@
 load ../_helpers_govcms
 
 setup() {
-  if [ ! -f "/tmp/bats/settings.php" ]; then
+  if [ ! -f "/tmp/bats/all.settings.php" ]; then
     mkdir -p /tmp/bats
     (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/all.settings.php)
   fi
 }
 
 settings() {
-  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/settings.php)
+  JSON=$(./tests/drupal-settings-to-json.php /tmp/bats/all.settings.php)
   echo "$JSON"
 }
 

--- a/tests/drupal-settings-to-json.php
+++ b/tests/drupal-settings-to-json.php
@@ -1,6 +1,16 @@
 #!/usr/bin/env php
 <?php
 
+ini_set('display_errors',0);
+
+// Argument 1 must contain path to settings file to parse.
+if (empty($argv[1])) {
+  echo "FAILED: Must provide settings filename as a first parameter.";
+  exit(1);
+}
+
+$settings_file = $argv[1];
+
 // Test contexts.
 $http_host = getenv('HTTP_HOST') ?: 'test.gov.au';
 $installation_attempted = getenv('INSTALLATION_ATTEMPTED') ?: FALSE;
@@ -31,7 +41,7 @@ else {
 putenv('GOVCMS_DRUPAL_SETTINGS=./drupal/settings');
 
 // Copy of settings.php from scaffold placed during bats `setup`
-$scaffold_settings_dot_php = '/tmp/bats/settings.php';
+$scaffold_settings_dot_php = $argv[1];
 if (!file_exists($scaffold_settings_dot_php)) {
   echo 'See drupal-settings.bats setup() for how download and setup ' . $scaffold_settings_dot_php;
 }


### PR DESCRIPTION
- Removed legacy solr configuration (included in all.settings.php anyway)
- Added missing environment indicator settings.
- Moved from deprecated drupal_installation_attempted() method.

This PR aligns scaffold-tooling settings to those found in the govcms8lagoon image. Once merged we can remove all settings managed separately in downstream consumers (e.g: https://github.com/govCMS/govcms8lagoon/pull/197)