### PR TITLE
Split non-production settigs vs dev_mode.

### DIFF
--- a/drupal/settings/dev-mode.settings.php
+++ b/drupal/settings/dev-mode.settings.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * DEV_MODE specific settings. Included from settings.php.
+ */
+
+// See comment in all.settings.php.
+// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$govcms_includes = isset($govcms_includes) ? $govcms_includes : __DIR__;
+
+/**
+ * Include the corresponding *.services.yml.
+ */
+// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$settings['container_yamls'][] = $govcms_includes . '/development.services.yml';
+
+/**
+ * Show all error messages, with backtrace information.
+ *
+ * In case the error level could not be fetched from the database, as for
+ * example the database connection failed, we rely only on this value.
+ */
+$config['system.logging']['error_level'] = 'verbose';
+
+/**
+ * Set expiration of cached pages to 0.
+ */
+$config['system.performance']['cache']['page']['max_age'] = 0;
+
+/**
+ * Disable CSS and JS aggregation.
+ */
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+/**
+ * Disable render caches for twig files to be reloaded on every page view.
+ */
+$settings['cache']['bins']['render'] = 'cache.backend.null';
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';

--- a/drupal/settings/development.settings.php
+++ b/drupal/settings/development.settings.php
@@ -6,48 +6,9 @@
  */
 
 /**
- * Include development services yml.
- */
-
-// See comment in all.settings.php.
-// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
-$govcms_includes = isset($govcms_includes) ? $govcms_includes : __DIR__;
-
-/**
- * Include the corresponding *.services.yml.
- */
-// phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable
-$settings['container_yamls'][] = $govcms_includes . '/development.services.yml';
-
-/**
- * Show all error messages, with backtrace information.
- *
- * In case the error level could not be fetched from the database, as for
- * example the database connection failed, we rely only on this value.
- */
-$config['system.logging']['error_level'] = 'verbose';
-
-/**
  * Disable Google Analytics from sending dev GA data.
  */
 $config['google_analytics.settings']['account'] = 'UA-XXXXXXXX-YY';
-
-/**
- * Set expiration of cached pages to 0.
- */
-$config['system.performance']['cache']['page']['max_age'] = 0;
-
-/**
- * Disable CSS and JS aggregation.
- */
-$config['system.performance']['css']['preprocess'] = FALSE;
-$config['system.performance']['js']['preprocess'] = FALSE;
-
-/**
- * Disable render caches for twig files to be reloaded on every page view.
- */
-$settings['cache']['bins']['render'] = 'cache.backend.null';
-$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
 
 /**
  * Configure stage file proxy.

--- a/drupal/settings/settings.php
+++ b/drupal/settings/settings.php
@@ -67,9 +67,12 @@ if (getenv('LAGOON')) {
 if (getenv('LAGOON_ENVIRONMENT_TYPE') && getenv('LAGOON_ENVIRONMENT_TYPE') == 'production') {
   include $govcms_includes . '/production.settings.php';
 }
+else {
+  include $govcms_includes . '/development.settings.php';
+}
 
 if (getenv('DEV_MODE') && getenv('DEV_MODE') == 'true') {
-  include $govcms_includes . '/development.settings.php';
+  include $govcms_includes . '/dev-mode.settings.php';
 }
 
 // Project specific overrides.


### PR DESCRIPTION
Ensures that non-production settings and `DEV_MODE` overrides are separated.