### PR TITLE
Define explicit parallel-lint dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         "webmozart/path-util": "^2.3",
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
+    "require-dev": {
+        "php-parallel-lint/php-parallel-lint": "^1.2"
+    },
     "bin": [
         "scripts/govcms-audit",
         "scripts/govcms-behat",

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,7 @@
         "phar-io/version": "1.0.1",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "zaporylie/composer-drupal-optimizations": "^1.0"
-    },
-    "require-dev": {
+        "zaporylie/composer-drupal-optimizations": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.2"
     },
     "bin": [

--- a/tests/bats/settings/environments.bats
+++ b/tests/bats/settings/environments.bats
@@ -28,6 +28,11 @@ setup() {
     mkdir -p /tmp/bats
     (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/lagoon.settings.php)
   fi
+
+  if [ ! -f "/tmp/bats/dev-mode.settings.php" ]; then
+    mkdir -p /tmp/bats
+    (cd /tmp/bats && curl -O https://raw.githubusercontent.com/govcms/scaffold-tooling/develop/drupal/settings/dev-mode.settings.php)
+  fi
 }
 
 settings() {


### PR DESCRIPTION
`parallel-lint` is used by the `govcms-lint` script but not explicitly defined as a tooling dependency