### PR TITLE
Updated behat binary path.

### DIFF
--- a/scripts/govcms-behat
+++ b/scripts/govcms-behat
@@ -6,4 +6,4 @@ set -euo pipefail
 APP_DIR="${APP_DIR:-/app}"
 BEHAT_PROFILE="${BEHAT_PROFILE:-}"
 
-"${APP_DIR}"/vendor/bin/behat --config "${APP_DIR}"/tests/behat/behat.yml --strict --colors "$BEHAT_PROFILE" "$@"
+"${APP_DIR}"/tests/vendor/bin/behat --config "${APP_DIR}"/tests/behat/behat.yml --strict --colors "$BEHAT_PROFILE" "$@"


### PR DESCRIPTION
Aligns with https://github.com/govCMS/govcms8lagoon/blob/develop/.docker/scripts/behat.

Behat binary lives in `/app/tests` vendor folder on default test images.