### PR TITLE
[GOVCMSD8-709] Lint docker compose.yml

### DIFF
--- a/scripts/validate/govcms-validate-platform-yml
+++ b/scripts/validate/govcms-validate-platform-yml
@@ -19,7 +19,7 @@ function join_char { local IFS="$1" shift; echo "$*"; }
 echo "GovCMS Validate :: Yaml lint platform files"
 
 if [ -z "${GOVCMS_PLATFORM_FILES}" ]; then
-  GOVCMS_PLATFORM_FILES=$(find . -type f \( -name '.lagoon.yml' \))
+  GOVCMS_PLATFORM_FILES=$(find . -type f \( -name '.lagoon.yml' -o -name 'docker-compose.yml' \))
 fi
 
 if [ -z "${GOVCMS_YAML_LINT}" ]; then

--- a/tests/bats/settings/environments.bats
+++ b/tests/bats/settings/environments.bats
@@ -52,6 +52,7 @@ settings() {
   [ "$(echo "$FILES" | jq '. | has("lagoon.settings.php")')" == "false" ]
   [ "$(echo "$FILES" | jq '. | has("production.settings.php")')" == "false" ]
   [ "$(echo "$FILES" | jq '. | has("development.settings.php")')" == "true" ]
+  [ "$(echo "$FILES" | jq '. | has("dev-mode.settings.php")')" == "true" ]
 }
 
 @test "Correct includes in dev mode (lagoon image)" {
@@ -67,6 +68,7 @@ settings() {
   [ "$(echo "$FILES" | jq '. | has("lagoon.settings.php")')" == "true" ]
   [ "$(echo "$FILES" | jq '. | has("production.settings.php")')" == "false" ]
   [ "$(echo "$FILES" | jq '. | has("development.settings.php")')" == "true" ]
+  [ "$(echo "$FILES" | jq '. | has("dev-mode.settings.php")')" == "true" ]
 }
 
 @test "Correct includes in production mode (not lagoon)" {


### PR DESCRIPTION
1. Adds docker-compose.yml file to govcms-validate-platform script. 
2. Fixes environments.bats tests after the recent change in #99.

**NOTE**
The docker-compose.yml file in govcms8-scaffold AND the new scaffold has invalid YAML syntax and there are two PRs to fix this: [govcms8-scaffold](https://github.com/govCMS/govcms8-scaffold/pull/55) and [new scaffold](https://github.com/govCMS/scaffold/pull/9). They need to be merged after that PR.