### PR TITLE
Fixed the path of Behat screenshots in CI.

### DIFF
--- a/.gitlab-ci-main.yml
+++ b/.gitlab-ci-main.yml
@@ -51,7 +51,7 @@ variables:
   artifacts:
     expire_in: "7 days"
     paths:
-      - tests/behat/features/screenshots
+      - tests/behat/screenshots
   stage: integration
   before_script:
     - |


### PR DESCRIPTION
GitLab CI artifacts are currently not captured due to misconfigured paths in CI config.


As per Behat config in the files below, the path is `%paths.base%/screenshots` rather than ` %paths.base%/features/screenshots`:
https://github.com/govCMS/GovCMS8/blob/1.x/tests/behat/behat.yml#L44
https://github.com/govCMS/scaffold/blob/develop/tests/behat/behat.yml#L44

Passing build with artifacts: https://projects.govcms.gov.au/nsw-ipart/ipart/-/jobs/633569