### PR TITLE
Improve audit output when config files are not present

### DIFF
--- a/scripts/validate/govcms-validate-modules
+++ b/scripts/validate/govcms-validate-modules
@@ -28,7 +28,7 @@ GOVCMS_DISALLOWED_MODULES=(
 config_file=$(find "$GOVCMS_CONFIG_FOLDER_PATH" -type f \( -name "$GOVCMS_CORE_EXTENTION_FILE_NAME" \))
 echo "GovCMS Validate :: Verify enabled modules"
 if [ -z "${config_file}" ]; then
-  echo "Coudn't find core.extension.yml file."
+  echo "[info]: Configuration files not present. Couldn't find core.extension.yml file."
   exit 0
 fi
 

--- a/scripts/validate/govcms-validate-permissions
+++ b/scripts/validate/govcms-validate-permissions
@@ -24,6 +24,12 @@ if [ -z "${GOVCMS_FILE_LIST}" ]; then
   GOVCMS_FILE_LIST=$(find config/default -type f \( -name "$GOVCMS_ROLE_PATTERN" -not -name 'user.role.site_administrator.yml' \))
 fi
 
+# No configuration files.
+if [ -z "${GOVCMS_FILE_LIST}" ]; then
+  echo "[info]: Configuration files not present."
+  exit 0
+fi
+
 IFS_BAK="$IFS"
 IFS=$'\n'
 

--- a/scripts/validate/govcms-validate-profile
+++ b/scripts/validate/govcms-validate-profile
@@ -21,6 +21,12 @@ if [ -z "${GOVCMS_FILE_LIST}" ]; then
   GOVCMS_FILE_LIST=$(find config/default -type f -name "core.extension.yml")
 fi
 
+# No configuration files.
+if [ -z "${GOVCMS_FILE_LIST}" ]; then
+  echo "[info]: Configuration files not present."
+  exit 0
+fi
+
 IFS_BAK="$IFS"
 IFS=$'\n'
 

--- a/scripts/validate/govcms-validate-tfa
+++ b/scripts/validate/govcms-validate-tfa
@@ -21,6 +21,12 @@ if [ -z "${GOVCMS_FILE_LIST}" ]; then
   GOVCMS_FILE_LIST=$(find config/default -type f -name "tfa.settings.yml")
 fi
 
+# No configuration files.
+if [ -z "${GOVCMS_FILE_LIST}" ]; then
+  echo "[info]: Configuration files not present."
+  exit 0
+fi
+
 IFS_BAK="$IFS"
 IFS=$'\n'
 


### PR DESCRIPTION
Previous outputs would indicate a successful result which may not be true when active scans take place.