### PR TITLE
[GOVCMSD9-538] Added govcms_security as a dependency.

### DIFF
--- a/scripts/deploy/govcms-enable_modules
+++ b/scripts/deploy/govcms-enable_modules
@@ -33,6 +33,7 @@ PLATFORM_MODULES=(
   "robotstxt"
   "lagoon_logs"
   "environment_indicator"
+  "govcms_security"
 )
 
 MODULE_LIST=""


### PR DESCRIPTION
Ensure `govcms_security` is added on deployment.