### PR TITLE
[GOVCMSD9-468] Updated trusted host patterns

### DIFF
--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -153,3 +153,9 @@ else {
   $config['seckit.settings']['seckit_ssl']['hsts_max_age'] = 0;
   $config['seckit.settings']['seckit_ssl']['hsts_subdomains'] = FALSE;
 }
+
+// Trusted host patterns are not necessary on lagoon as traffic will only
+// be routed to your site via the routes (hosts) defined in .lagoon.yml.
+if (getenv('LAGOON')) {
+  $settings['trusted_host_patterns'][] = '.*';
+}


### PR DESCRIPTION
Trusted host patterns are not relevant to GovCMS/Lagoon as routes are predefined and expected.

However an error/warning may display suggesting it is misconfigured.

Provide a simple default value that allows all host patterns to prevent the warning from displaying