### PR TITLE
Update phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,8 @@ parameters:
     - php
     - theme
     - inc
+  ignore_errors:
+    - "function not found"
   banned_code:
     nodes:
       - type: Expr_FuncCall

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,7 @@ parameters:
     - theme
     - inc
   ignore_errors:
-    - "function not found"
+    - "Function (.*) not found"
   banned_code:
     nodes:
       - type: Expr_FuncCall

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,8 +8,8 @@ parameters:
     - php
     - theme
     - inc
-  ignore_errors:
-    - "Function (.*) not found"
+  ignoreErrors:
+    - "#Function (.*) not found#"
   banned_code:
     nodes:
       - type: Expr_FuncCall

--- a/tests/bats/validate/fixtures/banned_functions/func_not_found.inc
+++ b/tests/bats/validate/fixtures/banned_functions/func_not_found.inc
@@ -1,0 +1,6 @@
+<?php
+
+function hook_init() {
+  filter_formats('test', 'test');
+  system_region_list('test');
+}

--- a/tests/bats/validate/fixtures/banned_functions/phpstan.neon
+++ b/tests/bats/validate/fixtures/banned_functions/phpstan.neon
@@ -1,9 +1,15 @@
 parameters:
+  excludePaths:
+    - /app/vendor/*
+  scanDirectories:
+    - /app
   level: 0
   fileExtensions:
     - php
     - theme
     - inc
+  ignoreErrors:
+    - "#Function (.*) not found#"
   banned_code:
     nodes:
       - type: Expr_FuncCall

--- a/tests/bats/validate/govcms-validate-php-functions.bats
+++ b/tests/bats/validate/govcms-validate-php-functions.bats
@@ -94,3 +94,14 @@ load ../_helpers_govcms
   assert_output_contains "14     Should not use function \"posix_setuid\", please change the code."
   assert_output_contains "16     Should not use function \"posix_uname\", please change the code."
 }
+
+@test "Check function not found" {
+  export GOVCMS_SCAFFOLD_TOOLING_DIR=tests/bats/validate/fixtures/banned_functions
+  export GOVCMS_RESULTS_STDOUT=1
+  export GOVCMS_THEME_DIR=tests/bats/validate/fixtures/banned_functions/func_not_found.inc
+
+  run scripts/validate/govcms-validate-php-functions >&3
+
+  assert_output_not_contains "Function filter_formats not found"
+  assert_output_not_contains "Function system_region_list not found"
+}

--- a/tests/bats/validate/govcms-validate-theme-yml.bats
+++ b/tests/bats/validate/govcms-validate-theme-yml.bats
@@ -46,7 +46,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Yaml lint theme files"
   assert_output_contains "[info]: Skip tests/bats/validate/fixtures/node_modules/test.yml"
-  assert_equal 49 "$(mock_get_call_num "${mock_yaml_lint}")"
+  assert_equal 50 "$(mock_get_call_num "${mock_yaml_lint}")"
 }
 
 @test "Validate theme yaml: Custom exclusion list" {


### PR DESCRIPTION
```
cli-drupal:/app$ bats tests/bats/validate/govcms-validate-php-functions.bats
1..7
BATS_TEST_TMPDIR dir: /tmp/bats-test-tmp-5h5n
ok 1 Check banned PHP functions: defaults
ok 2 Check banned PHP functions: theme file
ok 3 Check banned PHP functions: inc file
ok 4 Check banned PHP functions: system functions
ok 5 Check banned PHP functions: net functions
ok 6 Check banned PHP functions: posix functions
ok 7 Check function not found
```