### PR TITLE
Deprecate Drutiny and govcms-audit

### DIFF
--- a/scripts/govcms-audit
+++ b/scripts/govcms-audit
@@ -2,22 +2,11 @@
 IFS=$'\n\t'
 set -euo pipefail
 
-APP_DIR="${APP_DIR:-/app}"
-CUR_DIR="$(pwd)"
+GOVCMS_REPORT_MODE=${GOVCMS_REPORT_MODE:-1}
 
-# @todo. Review.
-# This seems a bit weird. We need audit-site to copy into the project so it can
-# be run with @self - a drutiny limitation - but we don't do it in setup-full.sh
-# so that it can be run locally (setup-full.sh is only in gitlab). There are a
-# lot of assumptions that need to be visited.
-if [[ ! -d "$APP_DIR/audit-site" ]]; then
-  # Assume https://github.com/govcms/audit-site is built at /opt/audit-site.
-  cp -Rf /opt/audit-site "$APP_DIR"
-  # Assume this is fully built at /opt.
-  chmod 775 "$APP_DIR/audit-site/vendor/bin/drutiny"
+echo "[Deprecation]: GovCMS audit-site is deprecated and will be removed in scaffold-tooling@3.3.0"
+
+if [[ GOVCMS_REPORT_MODE -ne 1 ]]; then
+  echo '[fail]: Deprecated script used.'
+  exit 1
 fi
-
-cd "$APP_DIR/audit-site"
-./vendor/bin/drutiny profile:run d8-full --exit-on-severity=high @self
-
-cd "$CUR_DIR"

--- a/tests/bats/integration.bats
+++ b/tests/bats/integration.bats
@@ -55,7 +55,6 @@ load _helpers_govcms
   composer require govcms/scaffold-tooling:dev-"${LATEST_DEV_VERSION}" --no-interaction --ignore-platform-reqs --update-with-dependencies
 
   # Ensure the binaries are available.
-  assert_file_exists vendor/bin/govcms-audit
   assert_file_exists vendor/bin/govcms-behat
   assert_file_exists vendor/bin/govcms-lint
   assert_file_exists vendor/bin/govcms-lint-distro


### PR DESCRIPTION
- Removes Drutiny reference which is deprecated for the `govcms-ship-shape` audit script