### PR TITLE
Fixed config export script.

### DIFF
--- a/scripts/deploy/govcms-config-backup
+++ b/scripts/deploy/govcms-config-backup
@@ -29,7 +29,7 @@ fi
 echo "[info]: Preparing config backup"
 
 drush config:export sync -y --destination "$GOVCMS_BACKUP_DIR/config"
-tar -czf "$GOVCMS_BACKUP_DIR/$GOVCMS_CONFIG_BACKUP.tar.gz" -C "$GOVCMS_BACKUP_DIR/config" --remove-files
+tar -czf "$GOVCMS_BACKUP_DIR/$GOVCMS_CONFIG_BACKUP.tar.gz" -C "$GOVCMS_BACKUP_DIR/config" . --remove-files
 
 echo "[info]: Saved to $GOVCMS_BACKUP_DIR/$GOVCMS_CONFIG_BACKUP.tar.gz"
 


### PR DESCRIPTION
Fixes `Cowardly refusing to create an empty archive` 

The `-C` flag specifies the directory to change to prior to providing the file list, so we still need to pass the files path (`.`)