### PR TITLE
[GOVCMSD9-642] Update auto-detection for ship-shape validations.

### DIFF
--- a/scripts/govcms-ship-shape
+++ b/scripts/govcms-ship-shape
@@ -33,9 +33,9 @@ fi
 SCRIPT_DIR=${APP_DIR}/vendor/bin
 
 if [[ $DISABLE_ACTIVE -eq 0 ]]; then
-  GOVCMS_VALIDATE_SCRIPTS=$(find "$SCRIPT_DIR" -type l -name "govcms-validate-*")
+  GOVCMS_VALIDATE_SCRIPTS=$(find "$SCRIPT_DIR" -name "govcms-validate-*")
 else
-  GOVCMS_VALIDATE_SCRIPTS=$(find "$SCRIPT_DIR" -type l \( -name "govcms-validate-*" ! -name "*active*" \))
+  GOVCMS_VALIDATE_SCRIPTS=$(find "$SCRIPT_DIR" \( -name "govcms-validate-*" ! -name "*active*" \))
 fi
 
 XML_SCRIPT=$SCRIPT_DIR/govcms-prepare-xml

--- a/tests/bats/fixtures/links/govcms-validate-active-modules
+++ b/tests/bats/fixtures/links/govcms-validate-active-modules
@@ -1,0 +1,1 @@
+../../../../scripts/validate/govcms-validate-active-modules

--- a/tests/bats/fixtures/links/govcms-validate-active-permissions
+++ b/tests/bats/fixtures/links/govcms-validate-active-permissions
@@ -1,0 +1,1 @@
+../../../../scripts/validate/govcms-validate-active-permissions

--- a/tests/bats/fixtures/proxies/govcms-validate-active-modules
+++ b/tests/bats/fixtures/proxies/govcms-validate-active-modules
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "noop"

--- a/tests/bats/fixtures/proxies/govcms-validate-active-permissions
+++ b/tests/bats/fixtures/proxies/govcms-validate-active-permissions
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "noop"

--- a/tests/bats/govcms-ship-shape.bats
+++ b/tests/bats/govcms-ship-shape.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2002,SC2034
+
+load _helpers_govcms
+
+@test "Validate detection can find symlinks" {
+  SCRIPT_DIR=tests/bats/fixtures/links
+  FILES=$(find "$SCRIPT_DIR" -name "govcms-validate-*")
+
+  i=0
+  for file in $FILES; do
+    ((i=i+1))
+  done
+
+  assert_equal 2 "$i"
+  assert_equal "tests/bats/fixtures/links/govcms-validate-active-modules" $FILES[0]
+}
+
+@test "Validate detection can find proxies" {
+  SCRIPT_DIR=tests/bats/fixtures/proxies
+  FILES=$(find "$SCRIPT_DIR" -name "govcms-validate-*")
+
+  i=0
+  for file in $FILES; do
+    ((i=i+1))
+  done
+
+  assert_equal 2 "$i"
+  assert_equal "tests/bats/fixtures/proxies/govcms-validate-active-modules" $FILES[0]
+}

--- a/tests/bats/govcms-ship-shape.bats
+++ b/tests/bats/govcms-ship-shape.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# shellcheck disable=SC2002,SC2034
+# shellcheck disable=SC2002,SC2034,SC1087,SC2086
 
 load _helpers_govcms
 


### PR DESCRIPTION
A recent change to compose changed how dependency binaries are included in the `bin` directory. They are no longer symlinked, sometimes they are now `proxied` this means that the auto script detection process could no longer find the scripts to execute.