### PR TITLE
Exclude paths from phpstan.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,9 @@
 parameters:
   excludePaths:
     - /app/vendor/*
+    - */assets/src/lib/campaignmonitor/samples/*
+    - */tests/*
+    - */bootstrap/scripts/*
   scanDirectories:
     - /app
   level: 0


### PR DESCRIPTION
Tests, Bootstrap script and CampaignMonitor samples have been ignored.

This follows reports from the bulk audit that was generating false positives.