### PR TITLE
GOVCMS-6775: Add more functions to the banned list.

### DIFF
--- a/classPHPStanAliases.php
+++ b/classPHPStanAliases.php
@@ -1,6 +1,0 @@
-<?php
-
-interface foo {}
-
-class_alias(\Foo::class, 'Drupal\markdown\Plugin\Markdown\AllowedHtmlInterface');
-class_alias(\Foo::class, 'Drupal\markdown\Plugin\Markdown\ParserInterface');

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
     "drupal/clamav": "^2.0",
     "drupal/config_ignore": "^2.3",
     "drupal/fast_404": "^2.0-alpha6",
-    "ekino/phpstan-banned-code": "^0.4.0",
-    "phpstan/extension-installer": "^1.0"
+    "ekino/phpstan-banned-code": "^0.4.0"
   },
   "require-dev": {
     "phar-io/manifest": "~1",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "drupal/clamav": "^2.0",
     "drupal/config_ignore": "^2.3",
     "drupal/fast_404": "^2.0-alpha6",
-    "ekino/phpstan-banned-code": "^0.4.0"
+    "phpstan/extension-installer": "^1.1.0",
+    "spaze/phpstan-disallowed-calls": "^2.3.0"
   },
   "require-dev": {
     "phar-io/manifest": "~1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,12 +1,3 @@
-parametersSchema:
-  # Copied from https://github.com/ekino/phpstan-banned-code/blob/v0.4.0/extension.neon.
-  banned_code: structure([
-    nodes: listOf(structure([
-      type: string()
-      functions: schema(listOf(string()), nullable())
-    ]))
-  ])
-
 parameters:
   # Disable all phpstan rules.
   customRulesetUsed: true
@@ -23,136 +14,87 @@ parameters:
     - inc
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:
-    - message: "#^Should not use function \"debug_backtrace\", please change the code\\.$#"
+    - message: '#^Calling debug_backtrace\(\) is forbidden, please change the code$#'
       count: 1
       path: /app/web/themes/custom/bootstrap/src/Bootstrap.php
-    - message: "#^Should not use function \"print_r\", please change the code\\.$#"
+    - message: '#^Calling print_r\(\) is forbidden, please change the code$#'
       count: 1
       path: /app/web/themes/custom/bootstrap/src/Bootstrap.php
-  banned_code:
-    nodes:
-      - type: Expr_FuncCall
-        functions:
-          - curl_exec
-          - curl_init
-          - curl_multi_exec
-          - db_query
-          - db_merge
-          - db_update
-          - db_write_record
-          - db_result
-          - db_set_active
-          - db_insert
-          - db_delete
-          - dd
-          - debug_backtrace
-          - dump
-          - escapeshellcmd
-          - exec
-          - ftp_connect
-          - ftp_exec
-          - ftp_get
-          - ftp_login
-          - ftp_nb_fput
-          - ftp_put
-          - ftp_raw
-          - ftp_rawlist
-          - mysql_affected_rows
-          - mysql_client_encoding
-          - mysql_close
-          - mysql_connect
-          - mysql_create_db
-          - mysql_data_seek
-          - mysql_db_name
-          - mysql_db_query
-          - mysql_drop_db
-          - mysql_errno
-          - mysql_error
-          - mysql_escape_string
-          - mysql_fetch_array
-          - mysql_fetch_assoc
-          - mysql_fetch_field
-          - mysql_fetch_lengths
-          - mysql_fetch_object
-          - mysql_fetch_row
-          - mysql_field_flags
-          - mysql_field_len
-          - mysql_field_name
-          - mysql_field_seek
-          - mysql_field_table
-          - mysql_field_type
-          - mysql_free_result
-          - mysql_get_client_info
-          - mysql_get_host_info
-          - mysql_get_proto_info
-          - mysql_get_server_info
-          - mysql_info
-          - mysql_insert_id
-          - mysql_list_dbs
-          - mysql_list_fields
-          - mysql_list_processes
-          - mysql_list_tables
-          - mysql_num_fields
-          - mysql_num_rows
-          - mysql_pconnect
-          - mysql_ping
-          - mysql_query
-          - mysql_real_escape_string
-          - mysql_result
-          - mysql_select_db
-          - mysql_set_charset
-          - mysql_stat
-          - mysql_tablename
-          - mysql_thread_id
-          - mysql_unbuffered_query
-          - passthru
-          - pcntl_alarm
-          - pcntl_async_signals
-          - pcntl_errno
-          - pcntl_exec
-          - pcntl_fork
-          - pcntl_get_last_error
-          - pcntl_getpriority
-          - pcntl_setpriority
-          - pcntl_signal_dispatch
-          - pcntl_signal_get_handler
-          - pcntl_signal
-          - pcntl_sigprocmask
-          - pcntl_sigtimedwait
-          - pcntl_sigwaitinfo
-          - pcntl_strerror
-          - pcntl_unshare
-          - pcntl_wait
-          - pcntl_waitpid
-          - pcntl_wexitstatus
-          - pcntl_wifexited
-          - pcntl_wifsignaled
-          - pcntl_wifstopped
-          - pcntl_wstopsig
-          - pcntl_wtermsig
-          - phpinfo
-          - popen
-          - posix_getpwuid
-          - posix_kill
-          - posix_mkfifo
-          - posix_setpgid
-          - posix_setsid
-          - posix_setuid
-          - posix_uname
-          - print_r
-          - proc_open
-          - proc_get_status
-          - proc_terminate
-          - proc_close
-          - proc_nice
-          - shell_exec
-          - sleep
-          - system
-          - var_dump
-
-services:
-  - class: Ekino\PHPStanBannedCode\Rules\BannedNodesRule
-    tags:
-      - phpstan.rules.rule
-    arguments:
-      - '%banned_code.nodes%'
+  disallowedFunctionCalls:
+    - function: 'curl_exec()'
+      message: 'please change the code'
+    - function: 'curl_init()'
+      message: 'please change the code'
+    - function: 'curl_multi_exec()'
+      message: 'please change the code'
+    - function: 'db_*()'
+      message: 'please change the code'
+    - function: 'dd()'
+      message: 'please change the code'
+    - function: 'debug_backtrace()'
+      message: 'please change the code'
+    - function: 'dump()'
+      message: 'please change the code'
+    - function: 'escapeshellcmd()'
+      message: 'please change the code'
+    - function: 'eval()'
+      message: 'please change the code'
+    - function: 'exec()'
+      message: 'please change the code'
+    - function: 'ftp_*()'
+      message: 'please change the code'
+    - function: 'mysql_*()'
+      message: 'please change the code'
+    - function: 'mysqli_*()'
+      message: 'please change the code'
+    - function: 'passthru()'
+      message: 'please change the code'
+    - function: 'pcntl_*()'
+      message: 'please change the code'
+    - function: 'phpinfo()'
+      message: 'please change the code'
+    - function: 'popen()'
+      message: 'please change the code'
+    - function: 'posix_getpwuid()'
+      message: 'please change the code'
+    - function: 'posix_kill()'
+      message: 'please change the code'
+    - function: 'posix_mkfifo()'
+      message: 'please change the code'
+    - function: 'posix_setpgid()'
+      message: 'please change the code'
+    - function: 'posix_setsid()'
+      message: 'please change the code'
+    - function: 'posix_setuid()'
+      message: 'please change the code'
+    - function: 'posix_uname()'
+      message: 'please change the code'
+    - function: 'print_r()'
+      message: 'please change the code'
+    - function: 'proc_open()'
+      message: 'please change the code'
+    - function: 'proc_get_status()'
+      message: 'please change the code'
+    - function: 'proc_terminate()'
+      message: 'please change the code'
+    - function: 'proc_close()'
+      message: 'please change the code'
+    - function: 'proc_nice()'
+      message: 'please change the code'
+    - function: 'shell_exec()'
+      message: 'please change the code'
+    - function: 'sleep()'
+      message: 'please change the code'
+    - function: 'system()'
+      message: 'please change the code'
+    - function: 'var_dump()'
+      message: 'please change the code'
+  disallowedMethodCalls:
+    - function: 'mysqli::*()'
+      message: 'please change the code'
+    - function: 'SQLite3::*()'
+      message: 'please change the code'
+    - function: 'SQLite3Stmt::*()'
+      message: 'please change the code'
+    - function: 'SQLite3Result::*()'
+      message: 'please change the code'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,15 @@
+parametersSchema:
+  # Copied from https://github.com/ekino/phpstan-banned-code/blob/v0.4.0/extension.neon.
+  banned_code: structure([
+    nodes: listOf(structure([
+      type: string()
+      functions: schema(listOf(string()), nullable())
+    ]))
+  ])
+
 parameters:
+  # Disable all phpstan rules.
+  customRulesetUsed: true
   excludePaths:
     - /app/vendor/*
     - */assets/src/lib/campaignmonitor/samples/*
@@ -6,33 +17,33 @@ parameters:
     - */bootstrap/scripts/*
   scanDirectories:
     - /app
-  level: 0
   fileExtensions:
     - php
     - theme
     - inc
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:
-    - "#Function (.*) not found#"
-    - "#^Call to static method (.*) on an unknown class (.*)$#"
-    - "#^Static call to instance method (.*)$#"
-    - "#^Unsafe usage of new static\\(\\)\\.$#"
-    - "#^Method (.*) should return bool but return statement is missing\\.$#"
-    - "#Should not use node with type \"Expr_Exit\", please change the code.#"
     - message: "#^Should not use function \"debug_backtrace\", please change the code\\.$#"
       count: 1
       path: /app/web/themes/custom/bootstrap/src/Bootstrap.php
     - message: "#^Should not use function \"print_r\", please change the code\\.$#"
       count: 1
       path: /app/web/themes/custom/bootstrap/src/Bootstrap.php
-  bootstrapFiles:
-    - classPHPStanAliases.php
   banned_code:
     nodes:
       - type: Expr_FuncCall
         functions:
           - curl_exec
+          - curl_init
           - curl_multi_exec
+          - db_query
+          - db_merge
+          - db_update
+          - db_write_record
+          - db_result
+          - db_set_active
+          - db_insert
+          - db_delete
           - dd
           - debug_backtrace
           - dump
@@ -46,7 +57,79 @@ parameters:
           - ftp_put
           - ftp_raw
           - ftp_rawlist
+          - mysql_affected_rows
+          - mysql_client_encoding
+          - mysql_close
+          - mysql_connect
+          - mysql_create_db
+          - mysql_data_seek
+          - mysql_db_name
+          - mysql_db_query
+          - mysql_drop_db
+          - mysql_errno
+          - mysql_error
+          - mysql_escape_string
+          - mysql_fetch_array
+          - mysql_fetch_assoc
+          - mysql_fetch_field
+          - mysql_fetch_lengths
+          - mysql_fetch_object
+          - mysql_fetch_row
+          - mysql_field_flags
+          - mysql_field_len
+          - mysql_field_name
+          - mysql_field_seek
+          - mysql_field_table
+          - mysql_field_type
+          - mysql_free_result
+          - mysql_get_client_info
+          - mysql_get_host_info
+          - mysql_get_proto_info
+          - mysql_get_server_info
+          - mysql_info
+          - mysql_insert_id
+          - mysql_list_dbs
+          - mysql_list_fields
+          - mysql_list_processes
+          - mysql_list_tables
+          - mysql_num_fields
+          - mysql_num_rows
+          - mysql_pconnect
+          - mysql_ping
+          - mysql_query
+          - mysql_real_escape_string
+          - mysql_result
+          - mysql_select_db
+          - mysql_set_charset
+          - mysql_stat
+          - mysql_tablename
+          - mysql_thread_id
+          - mysql_unbuffered_query
           - passthru
+          - pcntl_alarm
+          - pcntl_async_signals
+          - pcntl_errno
+          - pcntl_exec
+          - pcntl_fork
+          - pcntl_get_last_error
+          - pcntl_getpriority
+          - pcntl_setpriority
+          - pcntl_signal_dispatch
+          - pcntl_signal_get_handler
+          - pcntl_signal
+          - pcntl_sigprocmask
+          - pcntl_sigtimedwait
+          - pcntl_sigwaitinfo
+          - pcntl_strerror
+          - pcntl_unshare
+          - pcntl_wait
+          - pcntl_waitpid
+          - pcntl_wexitstatus
+          - pcntl_wifexited
+          - pcntl_wifsignaled
+          - pcntl_wifstopped
+          - pcntl_wstopsig
+          - pcntl_wtermsig
           - phpinfo
           - popen
           - posix_getpwuid
@@ -63,5 +146,13 @@ parameters:
           - proc_close
           - proc_nice
           - shell_exec
+          - sleep
           - system
           - var_dump
+
+services:
+  - class: Ekino\PHPStanBannedCode\Rules\BannedNodesRule
+    tags:
+      - phpstan.rules.rule
+    arguments:
+      - '%banned_code.nodes%'

--- a/tests/bats/validate/fixtures/banned_functions/phpstan.neon
+++ b/tests/bats/validate/fixtures/banned_functions/phpstan.neon
@@ -1,51 +1,99 @@
 parameters:
+  # Disable all phpstan rules.
+  customRulesetUsed: true
   excludePaths:
     - /app/vendor/*
+    - */assets/src/lib/campaignmonitor/samples/*
+    - */bootstrap/scripts/*
   scanDirectories:
     - /app
-  level: 0
   fileExtensions:
     - php
     - theme
     - inc
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:
-    - "#Function (.*) not found#"
-  banned_code:
-    nodes:
-      - type: Expr_FuncCall
-        functions:
-          - curl_exec
-          - curl_multi_exec
-          - dd
-          - debug_backtrace
-          - dump
-          - escapeshellcmd
-          - exec
-          - ftp_connect
-          - ftp_exec
-          - ftp_get
-          - ftp_login
-          - ftp_nb_fput
-          - ftp_put
-          - ftp_raw
-          - ftp_rawlist
-          - passthru
-          - phpinfo
-          - popen
-          - posix_getpwuid
-          - posix_kill
-          - posix_mkfifo
-          - posix_setpgid
-          - posix_setsid
-          - posix_setuid
-          - posix_uname
-          - print_r
-          - proc_open
-          - proc_get_status
-          - proc_terminate
-          - proc_close
-          - proc_nice
-          - shell_exec
-          - system
-          - var_dump
+    - message: '#^Calling debug_backtrace\(\) is forbidden, please change the code$#'
+      count: 1
+      path: /app/web/themes/custom/bootstrap/src/Bootstrap.php
+    - message: '#^Calling print_r\(\) is forbidden, please change the code$#'
+      count: 1
+      path: /app/web/themes/custom/bootstrap/src/Bootstrap.php
+  disallowedFunctionCalls:
+    - function: 'curl_exec()'
+      message: 'please change the code'
+    - function: 'curl_init()'
+      message: 'please change the code'
+    - function: 'curl_multi_exec()'
+      message: 'please change the code'
+    - function: 'db_*()'
+      message: 'please change the code'
+    - function: 'dd()'
+      message: 'please change the code'
+    - function: 'debug_backtrace()'
+      message: 'please change the code'
+    - function: 'dump()'
+      message: 'please change the code'
+    - function: 'escapeshellcmd()'
+      message: 'please change the code'
+    - function: 'eval()'
+      message: 'please change the code'
+    - function: 'exec()'
+      message: 'please change the code'
+    - function: 'ftp_*()'
+      message: 'please change the code'
+    - function: 'mysql_*()'
+      message: 'please change the code'
+    - function: 'mysqli_*()'
+      message: 'please change the code'
+    - function: 'passthru()'
+      message: 'please change the code'
+    - function: 'pcntl_*()'
+      message: 'please change the code'
+    - function: 'phpinfo()'
+      message: 'please change the code'
+    - function: 'popen()'
+      message: 'please change the code'
+    - function: 'posix_getpwuid()'
+      message: 'please change the code'
+    - function: 'posix_kill()'
+      message: 'please change the code'
+    - function: 'posix_mkfifo()'
+      message: 'please change the code'
+    - function: 'posix_setpgid()'
+      message: 'please change the code'
+    - function: 'posix_setsid()'
+      message: 'please change the code'
+    - function: 'posix_setuid()'
+      message: 'please change the code'
+    - function: 'posix_uname()'
+      message: 'please change the code'
+    - function: 'print_r()'
+      message: 'please change the code'
+    - function: 'proc_open()'
+      message: 'please change the code'
+    - function: 'proc_get_status()'
+      message: 'please change the code'
+    - function: 'proc_terminate()'
+      message: 'please change the code'
+    - function: 'proc_close()'
+      message: 'please change the code'
+    - function: 'proc_nice()'
+      message: 'please change the code'
+    - function: 'shell_exec()'
+      message: 'please change the code'
+    - function: 'sleep()'
+      message: 'please change the code'
+    - function: 'system()'
+      message: 'please change the code'
+    - function: 'var_dump()'
+      message: 'please change the code'
+  disallowedMethodCalls:
+    - function: 'mysqli::*()'
+      message: 'please change the code'
+    - function: 'SQLite3::*()'
+      message: 'please change the code'
+    - function: 'SQLite3Stmt::*()'
+      message: 'please change the code'
+    - function: 'SQLite3Result::*()'
+      message: 'please change the code'

--- a/tests/bats/validate/govcms-validate-php-functions.bats
+++ b/tests/bats/validate/govcms-validate-php-functions.bats
@@ -16,8 +16,10 @@ load ../_helpers_govcms
   run scripts/validate/govcms-validate-php-functions >&3
 
   assert_output_contains "GovCMS Validate :: Banned PHP function list"
-  assert_output_contains "4      Should not use function \"shell_exec\", please change the code."
-  assert_output_contains "6      Should not use function \"print_r\", please change the code."
+  assert_output_contains "4      Calling shell_exec() is forbidden, please change the code"
+  assert_output_contains "6      Calling print_r() is forbidden, please change the code"
+
+  assert_output_contains "[ERROR] Found 2 errors"
 }
 
 @test "Check banned PHP functions: inc file" {
@@ -28,8 +30,10 @@ load ../_helpers_govcms
   run scripts/validate/govcms-validate-php-functions >&3
 
   assert_output_contains "GovCMS Validate :: Banned PHP function list"
-  assert_output_contains "4      Should not use function \"dd\", please change the code."
-  assert_output_contains "6      Should not use function \"debug_backtrace\", please change the code."
+  assert_output_contains "4      Calling dd() is forbidden, please change the code"
+  assert_output_contains "6      Calling debug_backtrace() is forbidden, please change the code"
+
+  assert_output_contains "[ERROR] Found 2 errors"
 }
 
 @test "Check banned PHP functions: system functions" {
@@ -40,20 +44,22 @@ load ../_helpers_govcms
   run scripts/validate/govcms-validate-php-functions >&3
 
   assert_output_contains "GovCMS Validate :: Banned PHP function list"
-  assert_output_contains "4      Should not use function \"exec\", please change the code."
-  assert_output_contains "6      Should not use function \"system\", please change the code."
-  assert_output_contains "8      Should not use function \"shell_exec\", please change the code."
-  assert_output_contains "10     Should not use function \"popen\", please change the code."
+  assert_output_contains "4      Calling exec() is forbidden, please change the code"
+  assert_output_contains "6      Calling system() is forbidden, please change the code"
+  assert_output_contains "8      Calling shell_exec() is forbidden, please change the code"
+  assert_output_contains "10     Calling popen() is forbidden, please change the code"
 
-  assert_output_contains "12     Should not use function \"proc_open\", please change the code."
-  assert_output_contains "14     Should not use function \"proc_get_status\", please change the code."
-  assert_output_contains "16     Should not use function \"proc_terminate\", please change the code."
-  assert_output_contains "18     Should not use function \"proc_close\", please change the code."
-  assert_output_contains "20     Should not use function \"proc_nice\", please change the code."
+  assert_output_contains "12     Calling proc_open() is forbidden, please change the code"
+  assert_output_contains "14     Calling proc_get_status() is forbidden, please change the code"
+  assert_output_contains "16     Calling proc_terminate() is forbidden, please change the code"
+  assert_output_contains "18     Calling proc_close() is forbidden, please change the code"
+  assert_output_contains "20     Calling proc_nice() is forbidden, please change the code"
 
-  assert_output_contains "22     Should not use function \"passthru\", please change the code."
-  assert_output_contains "24     Should not use function \"escapeshellcmd\", please change the code."
-  assert_output_contains "27     Should not use node with type \"Expr_Eval\", please change the code."
+  assert_output_contains "22     Calling passthru() is forbidden, please change the code"
+  assert_output_contains "24     Calling escapeshellcmd() is forbidden, please change the code"
+  assert_output_contains "27     Calling eval() is forbidden, please change the code"
+
+  assert_output_contains "[ERROR] Found 12 errors"
 }
 
 @test "Check banned PHP functions: net functions" {
@@ -64,17 +70,20 @@ load ../_helpers_govcms
   run scripts/validate/govcms-validate-php-functions >&3
 
   assert_output_contains "GovCMS Validate :: Banned PHP function list"
-  assert_output_contains "5      Should not use function \"curl_exec\", please change the code."
-  assert_output_contains "8      Should not use function \"curl_multi_exec\", please change the code."
+  assert_output_contains "4      Calling curl_init() is forbidden, please change the code"
+  assert_output_contains "5      Calling curl_exec() is forbidden, please change the code"
+  assert_output_contains "8      Calling curl_multi_exec() is forbidden, please change the code"
 
-  assert_output_contains "12     Should not use function \"ftp_connect\", please change the code."
-  assert_output_contains "14     Should not use function \"ftp_exec\", please change the code."
-  assert_output_contains "16     Should not use function \"ftp_get\", please change the code."
-  assert_output_contains "18     Should not use function \"ftp_login\", please change the code."
-  assert_output_contains "20     Should not use function \"ftp_nb_fput\", please change the code."
-  assert_output_contains "22     Should not use function \"ftp_put\", please change the code."
-  assert_output_contains "24     Should not use function \"ftp_raw\", please change the code."
-  assert_output_contains "26     Should not use function \"ftp_rawlist\", please change the code."
+  assert_output_contains "12     Calling ftp_connect() is forbidden, please change the code"
+  assert_output_contains "14     Calling ftp_exec() is forbidden, please change the code"
+  assert_output_contains "16     Calling ftp_get() is forbidden, please change the code"
+  assert_output_contains "18     Calling ftp_login() is forbidden, please change the code"
+  assert_output_contains "20     Calling ftp_nb_fput() is forbidden, please change the code"
+  assert_output_contains "22     Calling ftp_put() is forbidden, please change the code"
+  assert_output_contains "24     Calling ftp_raw() is forbidden, please change the code"
+  assert_output_contains "26     Calling ftp_rawlist() is forbidden, please change the code"
+
+  assert_output_contains "[ERROR] Found 11 errors"
 }
 
 @test "Check banned PHP functions: posix functions" {
@@ -86,13 +95,15 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Banned PHP function list"
 
-  assert_output_contains "4      Should not use function \"posix_getpwuid\", please change the code."
-  assert_output_contains "6      Should not use function \"posix_kill\", please change the code."
-  assert_output_contains "8      Should not use function \"posix_mkfifo\", please change the code."
-  assert_output_contains "10     Should not use function \"posix_setpgid\", please change the code."
-  assert_output_contains "12     Should not use function \"posix_setsid\", please change the code."
-  assert_output_contains "14     Should not use function \"posix_setuid\", please change the code."
-  assert_output_contains "16     Should not use function \"posix_uname\", please change the code."
+  assert_output_contains "4      Calling posix_getpwuid() is forbidden, please change the code"
+  assert_output_contains "6      Calling posix_kill() is forbidden, please change the code"
+  assert_output_contains "8      Calling posix_mkfifo() is forbidden, please change the code"
+  assert_output_contains "10     Calling posix_setpgid() is forbidden, please change the code"
+  assert_output_contains "12     Calling posix_setsid() is forbidden, please change the code"
+  assert_output_contains "14     Calling posix_setuid() is forbidden, please change the code"
+  assert_output_contains "16     Calling posix_uname() is forbidden, please change the code"
+
+  assert_output_contains "[ERROR] Found 7 errors"
 }
 
 @test "Check function not found" {


### PR DESCRIPTION
Since the goal of the banned functions list is not to audit the code quality nor do syntax checks for the projects, but instead to only ensure no calls to banned functions are being made, I've disabled phpstan default checks, ~~as well as the ones from~~ removed the `ekino/phpstan-banned-code` extension, and used `spaze/phpstan-disallowed-calls` instead.

- ~~Removed phpstan extension installer so we can add ekino/phpstan-banned-code manually, while disabling all defaults.~~ Replaced `ekino/phpstan-banned-code` with `spaze/phpstan-disallowed-calls`, which allows for wildcard function names and method calls, which was missing in the former.
- Disabled default checks in phpstan.
- Added `mysql_*`, `pcntl_*` and a few other functions to the banned list.
- Added `mysqli::*()` & `SQLite3::*()` as banned method calls.