### PR TITLE
[GOVCMSD9-883] Enforce security.txt enable on prod.

### DIFF
--- a/drupal/settings/production.settings.php
+++ b/drupal/settings/production.settings.php
@@ -54,3 +54,9 @@ $config['lagoon_logs.settings']['host'] = getenv('LAGOON_LOGS_ENDPOINT') ?: 'app
 $config['lagoon_logs.settings']['port'] = 5140;
 $config['lagoon_logs.settings']['identifier'] = 'drupal';
 $config['lagoon_logs.settings']['disable'] = 0;
+
+/**
+ * Security.txt settings.
+ */
+// Security.txt must be enabled.
+$config['securitytxt.settings']['enabled'] = TRUE;


### PR DESCRIPTION
The 'securitytxt.settings.enabled' setting should be controlled in the settings.php file for production to ensure config imported cannot override them.