### PR TITLE
TFA validation fix

### DIFF
--- a/scripts/validate/govcms-validate-active-tfa
+++ b/scripts/validate/govcms-validate-active-tfa
@@ -16,7 +16,7 @@ echo "GovCMS Validate :: Validate TFA config on active site"
 TFA_CONFIG=$(drush config:get tfa.settings --format=json)
 
 TFA_ENABLED=$(jq -r '.enabled' <<< "${TFA_CONFIG}")
-if [[ "${TFA_ENABLED}" != 1 ]]; then
+if [[ "${TFA_ENABLED}" != 1 && "${TFA_ENABLED}" != 'true' ]]; then
   echo "[fail]: TFA not enabled"
   FAILURES="${FAILURES},${TFA_ENABLED}"
 else

--- a/scripts/validate/govcms-validate-tfa
+++ b/scripts/validate/govcms-validate-tfa
@@ -32,7 +32,7 @@ IFS=$'\n'
 
 for file in $GOVCMS_FILE_LIST; do
   TFA_ENABLED=$(yq r "$file" 'enabled')
-  if [[ "${TFA_ENABLED}" != 1 ]]; then
+  if [[ "${TFA_ENABLED}" != 1 && "${TFA_ENABLED}" != 'true' ]]; then
     echo "[fail]: TFA not enabled"
     FAILURES="${FAILURES},${TFA_ENABLED}"
   else

--- a/tests/bats/validate/fixtures/config/default/tfa.settings.invalid-2.yml
+++ b/tests/bats/validate/fixtures/config/default/tfa.settings.invalid-2.yml
@@ -1,0 +1,3 @@
+enabled: false
+required_roles:
+  authenticated: '0'

--- a/tests/bats/validate/fixtures/config/default/tfa.settings.valid-2.yml
+++ b/tests/bats/validate/fixtures/config/default/tfa.settings.valid-2.yml
@@ -1,0 +1,3 @@
+enabled: true
+required_roles:
+  authenticated: authenticated

--- a/tests/bats/validate/fixtures/tfa-invalid-2.json
+++ b/tests/bats/validate/fixtures/tfa-invalid-2.json
@@ -1,0 +1,9 @@
+{
+    "enabled": false,
+    "required_roles": {
+        "authenticated": "0",
+        "govcms_content_author": "0",
+        "govcms_content_approver": "0",
+        "govcms_site_administrator": "0"
+    }
+}

--- a/tests/bats/validate/fixtures/tfa-valid-2.json
+++ b/tests/bats/validate/fixtures/tfa-valid-2.json
@@ -1,0 +1,9 @@
+{
+    "enabled": true,
+    "required_roles": {
+        "authenticated": "authenticated",
+        "govcms_content_author": "0",
+        "govcms_content_approver": "0",
+        "govcms_site_administrator": "0"
+    }
+}

--- a/tests/bats/validate/govcms-validate-active-tfa.bats
+++ b/tests/bats/validate/govcms-validate-active-tfa.bats
@@ -39,8 +39,38 @@ load ../_helpers_govcms
   assert_failure
 }
 
+@test "Check active TFA: invalid 2" {
+  DRUSH_OUTPUT=$(cat tests/bats/validate/fixtures/tfa-invalid-2.json)
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "${DRUSH_OUTPUT}" 1
+
+  run scripts/validate/govcms-validate-active-tfa >&3
+
+  assert_output_contains "GovCMS Validate :: Validate TFA config on active site"
+  assert_output_contains "[fail]: TFA not enabled"
+  assert_output_contains "[fail]: TFA is not required for authenticated users"
+  assert_output_contains "[fail]: TFA is not actively enabled or enabled but not properly configured"
+
+  assert_failure
+}
+
 @test "Check active TFA: valid" {
   DRUSH_OUTPUT=$(cat tests/bats/validate/fixtures/tfa-valid.json)
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" "${DRUSH_OUTPUT}" 1
+
+  run scripts/validate/govcms-validate-active-tfa >&3
+
+  assert_output_contains "GovCMS Validate :: Validate TFA config on active site"
+  assert_output_contains "[info]: TFA is enabled"
+  assert_output_contains "[info]: TFA is required for authenticated users"
+  assert_output_contains "[success]: TFA is actively enabled and properly configured"
+
+  assert_success
+}
+
+@test "Check active TFA: valid 2" {
+  DRUSH_OUTPUT=$(cat tests/bats/validate/fixtures/tfa-valid-2.json)
   mock_drush=$(mock_command "drush")
   mock_set_output "${mock_drush}" "${DRUSH_OUTPUT}" 1
 

--- a/tests/bats/validate/govcms-validate-tfa.bats
+++ b/tests/bats/validate/govcms-validate-tfa.bats
@@ -22,6 +22,19 @@ load ../_helpers_govcms
   assert_failure
 }
 
+@test "Check TFA: invalid 2" {
+  export GOVCMS_FILE_LIST=$(find tests/bats/validate/fixtures -type f \( -name "tfa.settings.invalid-2.yml" \) -print0)
+
+  run scripts/validate/govcms-validate-tfa >&3
+
+  assert_output_contains "GovCMS Validate :: Validate TFA config"
+  assert_output_contains "[fail]: TFA not enabled"
+  assert_output_contains "[fail]: TFA is not required for authenticated users"
+  assert_output_contains "[fail]: TFA is not enabled or not properly configured"
+
+  assert_failure
+}
+
 @test "Check TFA: valid" {
   export GOVCMS_FILE_LIST=$(find tests/bats/validate/fixtures -type f \( -name "tfa.settings.valid.yml" \) -print0)
 
@@ -34,6 +47,20 @@ load ../_helpers_govcms
 
   assert_success
 }
+
+@test "Check TFA: valid 2" {
+  export GOVCMS_FILE_LIST=$(find tests/bats/validate/fixtures -type f \( -name "tfa.settings.valid-2.yml" \) -print0)
+
+  run scripts/validate/govcms-validate-tfa >&3
+
+  assert_output_contains "GovCMS Validate :: Validate TFA config"
+  assert_output_contains "[info]: TFA is enabled"
+  assert_output_contains "[info]: TFA is required for authenticated users"
+  assert_output_contains "[success]: TFA is enabled and properly configured"
+
+  assert_success
+}
+
 
 @test "Check TFA: enabled but not properly configured" {
   export GOVCMS_FILE_LIST=$(find tests/bats/validate/fixtures -type f \( -name "tfa.settings.valid-partial.yml" \) -print0)

--- a/tests/bats/validate/govcms-validate-theme-yml.bats
+++ b/tests/bats/validate/govcms-validate-theme-yml.bats
@@ -46,7 +46,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Yaml lint theme files"
   assert_output_contains "[info]: Skip tests/bats/validate/fixtures/node_modules/test.yml"
-  assert_equal 54 "$(mock_get_call_num "${mock_yaml_lint}")"
+  assert_equal 58 "$(mock_get_call_num "${mock_yaml_lint}")"
 }
 
 @test "Validate theme yaml: Custom exclusion list" {


### PR DESCRIPTION
The `tfa` module updated exported configuration, namely the enabled key changed from `1` to `true`.

This updates validation to accept either, adds tests.