### PR TITLE
[GOVCMSD9-1013] Update stage_file_proxy module from 1.2.0 to 2.0.2 and remove patch for Missing Content-Length header issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "drupal/lagoon_logs": "^1.0",
     "drupal/redis": "^1.4",
-    "drupal/stage_file_proxy": "1.2.0",
+    "drupal/stage_file_proxy": "2.0.2",
     "drush/drush": "~9 || ~10",
     "drupal/clamav": "^2.0",
     "drupal/config_ignore": "^2.3",
@@ -83,9 +83,6 @@
     "patches": {
       "drupal/purge": {
         "https://www.drupal.org/project/purge/issues/3259320": "https://www.drupal.org/files/issues/2022-02-24/3259320-10.patch"
-      },
-      "drupal/stage_file_proxy": {
-        "Missing Content-Length header": "https://www.drupal.org/files/issues/2020-05-03/stage_file_proxy-3075369-13-content-length.patch"
       }
     }
   }


### PR DESCRIPTION
This update should fix the issue with Stage File Proxy module throwing deprecated functions msg - GOVCMSD9-894. 