### PR TITLE
Shipshape - various adjustments and fixes.

### DIFF
--- a/scripts/validate/govcms-validate-illegal-files
+++ b/scripts/validate/govcms-validate-illegal-files
@@ -21,13 +21,6 @@ function illegal_file {
   return 1
 }
 
-function illegal_file {
-  if [[ "$1" =~ $GOVCMS_ILLEGAL_FILE_PATTERN(.+)?\.php ]]; then
-    return 0
-  fi
-  return 1
-}
-
 echo "GovCMS Validate :: Illegal files"
 
 if [ -n "${GOVCMS_FILE_LIST}" ]; then

--- a/scripts/validate/govcms-validate-permissions
+++ b/scripts/validate/govcms-validate-permissions
@@ -68,7 +68,7 @@ for file in $GOVCMS_FILE_LIST; do
     FAILURES="$FAILURES,$file"
     continue
   fi
-  if [[ $(yq r "$file" 'is_admin') == 'true' ]]; then
+  if [[ $(yq r "$file" 'is_admin') != 'false' ]]; then
     echo "[fail]: $file is listed as an admin role";
     FAILURES="$FAILURES,$file"
     continue

--- a/shipshape.yml
+++ b/shipshape.yml
@@ -5,7 +5,7 @@ checks:
       path: .
       disallowed-pattern: '^(adminer|phpmyadmin|bigdump)?\.php$'
     - name: '[FILE] Sensitive public files'
-      path: sites/default/files
+      path: web/sites/default/files
       disallowed-pattern: '.*\.(sql|php|sh|py|bz2|gz|tar|tgz|zip)?$'
   yaml:
     - name: '[FILE] Validate install profile'
@@ -78,7 +78,7 @@ checks:
     - name: '[FILE] Detect module files in theme folder'
       pattern: '.*\.info\.yml$'
       ignore-missing: true
-      path: themes
+      path: web/themes
       values:
         - key: type
           value: theme
@@ -172,7 +172,7 @@ checks:
       ignore-missing: true
     - name: '[FILE] Yaml lint theme files'
       severity: high
-      path: themes
+      path: web/themes
       pattern: '.*\.yml$'
       exclude-pattern: node_modules
       ignore-missing: true
@@ -181,4 +181,4 @@ checks:
       severity: high
       configuration: vendor/govcms/scaffold-tooling/phpstan.neon
       paths:
-        - themes
+        - web/themes

--- a/shipshape.yml
+++ b/shipshape.yml
@@ -2,7 +2,7 @@ checks:
   file:
     - name: '[FILE] Illegal files'
       severity: high
-      path: .
+      path: web
       disallowed-pattern: '^(adminer|phpmyadmin|bigdump)?\.php$'
     - name: '[FILE] Sensitive public files'
       path: web/sites/default/files
@@ -181,4 +181,5 @@ checks:
       severity: high
       configuration: vendor/govcms/scaffold-tooling/phpstan.neon
       paths:
-        - web/themes
+        - web/themes/custom
+        - themes

--- a/shipshape.yml
+++ b/shipshape.yml
@@ -2,10 +2,10 @@ checks:
   file:
     - name: '[FILE] Illegal files'
       severity: high
-      path: web
+      path: .
       disallowed-pattern: '^(adminer|phpmyadmin|bigdump)?\.php$'
     - name: '[FILE] Sensitive public files'
-      path: web/sites/default/files
+      path: sites/default/files
       disallowed-pattern: '.*\.(sql|php|sh|py|bz2|gz|tar|tgz|zip)?$'
   yaml:
     - name: '[FILE] Validate install profile'
@@ -78,7 +78,7 @@ checks:
     - name: '[FILE] Detect module files in theme folder'
       pattern: '.*\.info\.yml$'
       ignore-missing: true
-      path: web/themes
+      path: themes
       values:
         - key: type
           value: theme
@@ -164,9 +164,15 @@ checks:
         - synchronize configuration
         - use PHP for google analytics tracking visibility
   yamllint:
+    - name: '[FILE] Yaml lint platform files'
+      severity: high
+      files:
+        - .lagoon.yml
+        - docker-compose.yml
+      ignore-missing: true
     - name: '[FILE] Yaml lint theme files'
       severity: high
-      path: web/themes
+      path: themes
       pattern: '.*\.yml$'
       exclude-pattern: node_modules
       ignore-missing: true
@@ -175,4 +181,4 @@ checks:
       severity: high
       configuration: vendor/govcms/scaffold-tooling/phpstan.neon
       paths:
-        - web/themes
+        - themes

--- a/shipshape.yml
+++ b/shipshape.yml
@@ -17,8 +17,7 @@ checks:
           value: govcms
     - name: '[FILE] Disallowed permissions'
       severity: high
-      pattern: user.role.*.yml
-      exclude-pattern: language
+      pattern: '^user\.role\..*\.yml$'
       ignore-missing: true
       path: config/default
       values:
@@ -77,9 +76,9 @@ checks:
         - key: error_level
           value: hide
     - name: '[FILE] Detect module files in theme folder'
-      pattern: '.*.info.yml'
+      pattern: '.*\.info\.yml$'
       ignore-missing: true
-      path: 'themes'
+      path: web/themes
       values:
         - key: type
           value: theme
@@ -165,22 +164,10 @@ checks:
         - synchronize configuration
         - use PHP for google analytics tracking visibility
   yamllint:
-    - name: '[FILE] Yaml lint platform files'
-      severity: high
-      files:
-        - .lagoon.yml
-        - docker-compose.yml
-      ignore-missing: true
     - name: '[FILE] Yaml lint theme files'
       severity: high
       path: web/themes
-      pattern: ".*.yml"
-      exclude-pattern: node_modules
-      ignore-missing: true
-    - name: '[FILE] Yaml lint theme files (no web prefix)'
-      severity: high
-      path: themes
-      pattern: ".*.yml"
+      pattern: '.*\.yml$'
       exclude-pattern: node_modules
       ignore-missing: true
   phpstan:
@@ -188,5 +175,4 @@ checks:
       severity: high
       configuration: vendor/govcms/scaffold-tooling/phpstan.neon
       paths:
-        - web/themes/custom
-        - themes
+        - web/themes


### PR DESCRIPTION
# Changes
- Removed duplicated piece of code in `scripts/validate/govcms-validate-illegal-files`
- Flipped a check in `scripts/validate/govcms-validate-permissions` to explicitly assert for `is_admin` being set to false to avoid value `1` getting past the check.
- Adjusted regex pattern in `shipshape.yml` config for "[FILE] Disallowed permissions" check to target files more precisely.
- Adjusted regex pattern in `shipshape.yml` config for "[FILE] Detect module files in theme folder" check to target files more precisely.
- Adjusted `path` field values in `shipshape.yml` to remove "web" folder references as that can be set as a workdir when executing shipshape command.
-- Removed "[FILE] Yaml lint theme files (no web prefix)" check as duplicate.
- Adjusted regex pattern in `shipshape.yml` config for "[FILE] Yaml lint theme files" as it was catching non-YAML files.