### PR TITLE
Add `optional` for is admin check

### DIFF
--- a/shipshape.yml
+++ b/shipshape.yml
@@ -28,6 +28,7 @@ checks:
         - key: is_admin
           value: false
           truthy: true
+          optional: true
         - key: permissions
           is-list: true
           disallowed:


### PR DESCRIPTION
`is_admin` defaults to false if it is not defined a standard configuration export will omit this key if it is not set to true. This ensures that shipshape can correctly detect potential permission escalations.