### PR TITLE
[GOVCMSD9-1028] Disable event logging in database.

### DIFF
--- a/drupal/settings/security.settings.php
+++ b/drupal/settings/security.settings.php
@@ -97,3 +97,9 @@ $config['module_permissions.settings']['permission_blacklist'] = [
   'administer search_api',
   'assign all roles',
 ];
+
+/**
+* Event log track settings.
+*/
+// Disable Logging to DB
+$config['event_log_track.adminsettings']['disable_db_logs'] = 1;


### PR DESCRIPTION
All logs generated by Event track log module should be stored in syslog instead of in the database.