### PR TITLE
Shipshape - Removed language config exclusion from shipshape checks.

### DIFF
--- a/shipshape.yml
+++ b/shipshape.yml
@@ -30,7 +30,7 @@ checks:
           optional: true
         - key: permissions
           is-list: true
-          optiona: true
+          optional: true
           disallowed:
             - administer config permissions
             - administer modules

--- a/shipshape.yml
+++ b/shipshape.yml
@@ -21,7 +21,6 @@ checks:
     - name: '[FILE] Disallowed permissions'
       severity: high
       pattern: user.role.*.yml
-      exclude-pattern: language
       ignore-missing: true
       path: config/default
       values:
@@ -31,6 +30,7 @@ checks:
           optional: true
         - key: permissions
           is-list: true
+          optiona: true
           disallowed:
             - administer config permissions
             - administer modules


### PR DESCRIPTION
# Problem
Config files placed in config languages folder a re currently excluded.

# Proposed solution
Include languages config in shipshape checks and make critical attributes optional, as they are not required for language config.