### PR TITLE
Config import fix for Drush 11.

### DIFF
--- a/scripts/deploy/govcms-config-import
+++ b/scripts/deploy/govcms-config-import
@@ -46,7 +46,7 @@ fi
 
 if [ "$config_count" -gt 0 ]; then
   echo "[update]: Import site configuration."
-  drush config:import -y sync
+  drush config:import -y
 fi
 
 if [ "$LAGOON_ENVIRONMENT_TYPE" != "production" ] && [ "$dev_config_count" -gt 0 ]; then

--- a/scripts/govcms-deploy
+++ b/scripts/govcms-deploy
@@ -65,7 +65,7 @@ common_deploy () {
   # Base configuration import with development environment overrides.
   if [[ "$GOVCMS_DEPLOY_WORKFLOW_CONFIG" = "import" && "$config_count" -gt 0 ]]; then
     echo "Performing config import."
-    drush config:import -y sync
+    drush config:import -y
     if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" && "$dev_config_count" -gt 0 ]]; then
       echo "Performing development config import on non-production site."
       drush config:import -y --partial --source=../config/dev

--- a/tests/bats/deploy/govcms-config-import.bats
+++ b/tests/bats/deploy/govcms-config-import.bats
@@ -63,7 +63,7 @@ load ../_helpers_govcms
   assert_output_contains "GovCMS Deploy :: Configuration import"
   assert_output_contains "[update]: Import site configuration."
 
-  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "config:import -y" "$(mock_get_call_args "${mock_drush}" 2)"
   assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 }
 
@@ -125,7 +125,7 @@ load ../_helpers_govcms
   assert_output_contains "[update]: Import site configuration."
   assert_output_contains "[success]: Completed successfully."
 
-  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "config:import -y" "$(mock_get_call_args "${mock_drush}" 2)"
   assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 }
 
@@ -148,7 +148,7 @@ load ../_helpers_govcms
   assert_output_contains "[update]: Import dev configuration partially."
   assert_output_contains "[success]: Completed successfully."
 
-  assert_equal "config:import -y sync" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "config:import -y" "$(mock_get_call_args "${mock_drush}" 2)"
   assert_equal "config:import -y --source=${CONFIG_DEV_DIR} --partial" "$(mock_get_call_args "${mock_drush}" 3)"
   assert_equal 3 "$(mock_get_call_num "${mock_drush}")"
 }


### PR DESCRIPTION
Already included in the `10.x-develop` branch, but this backport allows PaaS D9 customers to use Drush 11 even if GovCMS does not move to Drush 11 as the default until D10.

The `sync` value has not been in use for some time anyway, so this makes no difference to the current state.