### PR TITLE
Shipshape - Added a new DB user role check configuration.

### DIFF
--- a/shipshape.yml
+++ b/shipshape.yml
@@ -177,6 +177,9 @@ checks:
         - import configuration
         - synchronize configuration
         - use PHP for google analytics tracking visibility
+  drupal-admin-user:
+    - name: '[DATABASE] Active user roles admin check'
+      severity: high
   yamllint:
     - name: '[FILE] Yaml lint platform files'
       severity: high


### PR DESCRIPTION
# Description
There is a PR for Shipshape that introduces a new active user role config check. Once merged, scaffold tooling should start using that check. (see  https://github.com/salsadigitalauorg/shipshape/pull/24)

# Proposed solution
Add the new configuration to `shipshape.yml `config file.