### PR TITLE
Upgraded Purge module dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "drupal/config_ignore": "^2.3",
     "drupal/fast_404": "^2.0-alpha6",
     "drupal/govcms_akamai_purge": "^1.0",
-    "drupal/purge": "3.2",
-    "drupal/purge_queuer_coretags": "3.2",
+    "drupal/purge": "3.4",
+    "drupal/purge_queuer_coretags": "3.4",
     "drupal/purge_purger_http": "^1.0",
     "phpstan/extension-installer": "^1.1.0",
     "spaze/phpstan-disallowed-calls": "^2.3.0",
@@ -77,13 +77,6 @@
       "drupal/core-composer-scaffold": true,
       "oomphinc/composer-installers-extender": true,
       "phpstan/extension-installer": true
-    }
-  },
-  "extra": {
-    "patches": {
-      "drupal/purge": {
-        "https://www.drupal.org/project/purge/issues/3259320": "https://www.drupal.org/files/issues/2022-02-24/3259320-10.patch"
-      }
     }
   }
 }


### PR DESCRIPTION
# Description
Purge modules have been updated to 3.4 which now include the patch.

# Proposed solution
Bump up the module version and remove the patch.