### PR TITLE
[GOVCMSD9-1052] Lock the Event log output type

### DIFF
--- a/drupal/settings/security.settings.php
+++ b/drupal/settings/security.settings.php
@@ -103,3 +103,5 @@ $config['module_permissions.settings']['permission_blacklist'] = [
 */
 // Disable Logging to DB
 $config['event_log_track.adminsettings']['disable_db_logs'] = 1;
+// Lock down event log output type.
+$config['event_log_track.settings']['output_type'] = 'watchdog';


### PR DESCRIPTION
Only the 'Watchdog' output type is compatible with Lagoon log.
The other option of 'Raw syslog' is not compatible with the Lagoon Logs module, that will stop event logs from outputting to OpenSearch.