### PR TITLE
[DEVOPS-191] Added APCu autoloader instead of Symphony APC.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
       "drupal/core-composer-scaffold": true,
       "oomphinc/composer-installers-extender": true,
       "phpstan/extension-installer": true
-    }
+    },
+    "apcu-autoloader": true
   }
 }

--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -141,6 +141,9 @@ if (in_array(PHP_SAPI, ['cli', 'cli-server'])) {
   }
 }
 
+// Prevents legacy Symfony ApcClassLoader from being used instead of Composer's.
+$settings['class_loader_auto_detect'] = FALSE;
+
 $config['search_api.server.lagoon_solr']['backend_config']['connector_config']['path'] = '/';
 $config['search_api.server.lagoon_solr']['backend_config']['connector_config']['core'] = 'drupal';
 


### PR DESCRIPTION
#  Issue
Blackfire.io reports 46% performance improvement and 90% I/O wait improvement when using APCu
[Twitter link](https://twitter.com/nmdmatt/status/1328902315164766208)

# Proposed solution
Disable legacy Symphony APC loader and add APCu instead.