### PR TITLE
[DEVOPS-191] Added APCu instead of legacy Symphony APC.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,5 +61,8 @@
     "scripts/validate/govcms-yaml_lint",
     "scripts/validate/govcms-module_verify",
     "scripts/validate/govcms-validate-illegal-files"
-  ]
+  ],
+  "config": {
+    "apcu-autoloader": true
+  }
 }

--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -128,6 +128,9 @@ if (defined('STDIN') || in_array(PHP_SAPI, ['cli', 'cli-server'])) {
 $config['search_api.server.lagoon_solr']['backend_config']['connector_config']['path'] = '/';
 $config['search_api.server.lagoon_solr']['backend_config']['connector_config']['core'] = 'drupal';
 
+// Prevents legacy Symfony ApcClassLoader from being used instead of Composer's.
+$settings['class_loader_auto_detect'] = FALSE;
+
 // Configure seckit to emit the HSTS headers when a user is likely visiting
 // govCMS using a domain with valid SSL.
 //


### PR DESCRIPTION
#  Issue
Blackfire.io reports 46% performance improvement and 90% I/O wait improvement when using APCu
[Twitter link](https://twitter.com/nmdmatt/status/1328902315164766208)

# Proposed solution
Disable legacy Symphony APC loader and add APCu instead.