### PR TITLE
Added Autoloader optimization config. (8.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
     "scripts/validate/govcms-validate-illegal-files"
   ],
   "config": {
-    "apcu-autoloader": true
+    "apcu-autoloader": true,
+    "optimize-autoloader": true
   }
 }


### PR DESCRIPTION
# Issue
By default, the Composer autoloader runs relatively fast. However, due to the way PSR-4 and PSR-0 autoloading rules are set up, it needs to check the filesystem before resolving a classname conclusively. This slows things down quite a bit, but it is convenient in development environments because when you add a new class it can immediately be discovered/used without having to rebuild the autoloader configuration.

The problem however is in production you generally want things to happen as fast as possible, as you can rebuild the configuration every time you deploy and new classes do not appear at random between deploys.

# Proposed solution
Add `optimize-autoloader` to `composer.json` config.