### PR TITLE
Fix: Validate 'is_admin' in active configuration.

### DIFF
--- a/scripts/validate/govcms-validate-active-permissions
+++ b/scripts/validate/govcms-validate-active-permissions
@@ -52,6 +52,14 @@ for role in ${RESTRICTED_ROLES_FOUND}; do
   FAILURES="$FAILURES,$role"
 done
 
+# Check the active database for 'is_admin'.
+for role in ${ROLES//,/ }; do
+  if [[ $(drush config:get "user.role.$role" is_admin --pipe) -eq 1 ]]; then
+    echo "[FAIL]; '$role' has is_admin";
+    FAILURES="$FAILURES,$role"
+  fi
+done
+
 if [ -x "${GOVCMS_PREPARE_XML_SCRIPT}" ]; then
   ${GOVCMS_PREPARE_XML_SCRIPT} --failures="${FAILURES}" --total="${ROLES}" --name="${GOVCMS_OUTFILE}" --fail-message="GovCMS.QA.IllegalActivePermissions"
 fi

--- a/tests/bats/validate/govcms-validate-active-permissions.bats
+++ b/tests/bats/validate/govcms-validate-active-permissions.bats
@@ -33,7 +33,7 @@ load ../_helpers_govcms
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"administer permissions\""
   assert_output_contains "[fail]: 'authenticated' has restricted permissions: \"administer permissions\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 3 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }
@@ -47,7 +47,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"administer modules\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }
@@ -61,7 +61,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"administer software updates\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }
@@ -75,7 +75,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"administer site configuration\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }
@@ -89,7 +89,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"synchronize configuration\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }
@@ -103,7 +103,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"administer config permissions\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }
@@ -117,7 +117,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"use PHP for google analytics tracking visibility\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }
@@ -131,7 +131,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"import configuration\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }
@@ -145,7 +145,7 @@ load ../_helpers_govcms
 
   assert_output_contains "GovCMS Validate :: Disallowed permissions on active site"
   assert_output_contains "[fail]: 'anonymous' has restricted permissions: \"administer site configuration,administer software updates\""
-  assert_equal 1 "$(mock_get_call_num "${mock_drush}")"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
 
   assert_failure
 }


### PR DESCRIPTION
- Fixes an issue where `is_admin` was not correctly being detected in active site scans.