### PR TITLE
[GOVCMSD8-772] Configure SwiftMailer to use correct mode.

### DIFF
--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -178,3 +178,6 @@ else {
 if (getenv('LAGOON')) {
   $settings['trusted_host_patterns'][] = '.*';
 }
+
+// Swiftmailer configuration.
+$config['swiftmailer.transport']['sendmail_mode'] = 't';


### PR DESCRIPTION
The config in the Admin page might still show `bs` as the mode if config has not been updated accordingly, but the test email should still work.