### PR TITLE
[DEVOPS-78] Added Slack notification for drush errors.

### DIFF
--- a/scripts/govcms-drush
+++ b/scripts/govcms-drush
@@ -55,7 +55,8 @@ EOF
 
 send_slack() {
   # Escape quotes.
-  ERROR=$(echo $1 | sed 's/"/*/g')
+  ERROR=$(echo $1 | sed 's/"/`/g')
+  TIMESTAMP=$(date +"%T")
   # Post payload.
   curl \
   -H "Content-type: application/json" \
@@ -85,7 +86,8 @@ send_slack() {
             "value":"'"$ERROR"'",
           }
         ],
-        "color":"danger"
+        "color":"danger",
+        "ts":"'"$TIMESTAMP"'"
       }]
     }
     '

--- a/scripts/govcms-drush
+++ b/scripts/govcms-drush
@@ -17,6 +17,9 @@ GOVCMS_DRUSH_RECIPIENTS=${GOVCMS_DRUSH_RECIPIENTS:-}
 GOVCMS_DRUSH_NOTIFICATION_ENABLE=${GOVCMS_DRUSH_NOTIFICATION_ENABLE:-false}
 LAGOON_PROJECT=${LAGOON_PROJECT:-'base project'}
 
+# Slack
+SLACK_URL='https://hooks.slack.com/services/'
+
 TMP=$(mktemp)
 COMMAND="drush $*"
 
@@ -32,6 +35,11 @@ send_errors() {
     TO="$TO,$GOVCMS_DRUSH_RECIPIENTS"
   fi
 
+  # Send Slack notification if token is set.
+  if [ -n "${SLACK_TOKEN}" ];then
+    send_slack "$ERROR"
+  fi
+
   sendmail $TO <<EOF
 Subject: $SUBJECT
 From: $FROM
@@ -43,6 +51,44 @@ $ERROR
 
 Please contact your development partner or support for assistance.
 EOF
+}
+
+send_slack() {
+  # Escape quotes.
+  ERROR=$(echo $1 | sed 's/"/*/g')
+  # Post payload.
+  curl \
+  -H "Content-type: application/json" \
+  -X POST $SLACK_URL$SLACK_TOKEN \
+  -d \
+    '
+    {
+      "attachments":[{
+        "pretext": "*GovCMS Drush command failed to complete successfully.*",
+        "fields":[
+          {
+            "title":"Project",
+            "value":"'"$LAGOON_PROJECT"'",
+            "short":"true"
+          },
+          {
+            "title":"Branch",
+            "value":"'"$LAGOON_GIT_BRANCH"'",
+            "short":"true"
+          },
+          {
+            "title":"Command",
+            "value":"'"$COMMAND"'",
+          },
+          {
+            "title":"Error",
+            "value":"'"$ERROR"'",
+          }
+        ],
+        "color":"danger"
+      }]
+    }
+    '
 }
 
 if $COMMAND 2> >(tee $TMP); then

--- a/scripts/govcms-drush
+++ b/scripts/govcms-drush
@@ -55,7 +55,8 @@ EOF
 
 send_slack() {
   # Escape quotes.
-  ERROR=$(echo $1 | sed 's/"/`/g')
+  local ERROR
+  ERROR=$(jq -n --arg msg "$1" '$msg')
   TIMESTAMP=$(date +"%T")
   # Post payload.
   curl \
@@ -83,7 +84,7 @@ send_slack() {
           },
           {
             "title":"Error",
-            "value":"'"$ERROR"'",
+            "value":"```'"$ERROR"'```",
           }
         ],
         "color":"danger",

--- a/scripts/govcms-drush
+++ b/scripts/govcms-drush
@@ -80,7 +80,7 @@ send_slack() {
           },
           {
             "title":"Command",
-            "value":"'"$COMMAND"'",
+            "value":"`'"$COMMAND"'`",
           },
           {
             "title":"Error",

--- a/scripts/govcms-drush
+++ b/scripts/govcms-drush
@@ -54,10 +54,10 @@ EOF
 }
 
 send_slack() {
-  # Escape quotes.
+  # Escape and truncate for JSON.
   local ERROR
-  ERROR=$(jq -n --arg msg "$1" '$msg')
-  TIMESTAMP=$(date +"%T")
+  ERROR="$(jq -n --arg msg "\`\`\`$(echo $1 | cut -f1,2 -d'[')\`\`\`" '$msg')"
+  TIMESTAMP=$(date +"%s")
   # Post payload.
   curl \
   -H "Content-type: application/json" \
@@ -84,7 +84,7 @@ send_slack() {
           },
           {
             "title":"Error",
-            "value":"```'"$ERROR"'```",
+            "value":'"$ERROR"',
           }
         ],
         "color":"danger",


### PR DESCRIPTION
#  Issue
System notifications would be more visible in Slack, this process currently triggers an email but most other notification systems notify a slack channel of a failure state. To ensure consistency between alerting and monitoring we should have the cron failures notify slack as well.

# Proposed solution
Expand on `govcms-drush` wrapper and add a `curl` call to Slack when an error is detected. 