### PR TITLE
[GOVCMSD10-375] Update event log track setting accordingly.

### DIFF
--- a/drupal/settings/security.settings.php
+++ b/drupal/settings/security.settings.php
@@ -102,7 +102,7 @@ $config['module_permissions.settings']['permission_blacklist'] = [
 * Event log track settings.
 */
 // Disable Logging to DB
-$config['event_log_track.adminsettings']['disable_db_logs'] = 1;
+$config['event_log_track.settings']['disable_db_logs'] = true;
 // Lock down event log output type.
 $config['event_log_track.settings']['output_type'] = 'watchdog';
 


### PR DESCRIPTION
Since Events log track module 3.1.9, the setting's name for database log has been changed to 'event_log_track.settings.disable_db_logs'.

Details see
https://git.drupalcode.org/project/events_log_track/-/commit/9b58cfbb9010ebc49a5a06ed7f083a1dcc856e87

Therefore, we have to update our setting file to change the setting's name accordingly.