### PR TITLE
[GOVCMS-9913] Added Symfony Mailer settings.

### DIFF
--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -53,6 +53,11 @@ if ($clam_mode == 0 || strtolower($clam_mode) == 'daemon') {
 // Non-deterministic hash salt.
 $settings['hash_salt'] = hash('sha256', getenv('MARIADB_HOST'));
 
+// Add custom symfony mailer transport command.
+$settings['mailer_sendmail_commands'] = [
+  ini_get('sendmail_path') . ' -t'
+];
+
 // Allow custom themes to provide custom 404 pages.
 // By placing a file called 404.html in the root of their theme repository.
 // 404 pages must be less than 512KB to be used. This is a performance


### PR DESCRIPTION
# Issue
Symfony Mailer module uses default command for sendmail with `-bs` flag that is not supported on GovCMS.

# Proposed changes
In accordance with [documentation](https://www.drupal.org/docs/contributed-modules/drupal-symfony-mailer/getting-started#s-mailer-transport) for Symfony Mailer, to change the default command it needs to be added via the settings file.