### PR TITLE
[GOVCMS-10068] Replaced obsolete --pipe format.

### DIFF
--- a/scripts/validate/govcms-validate-active-permissions
+++ b/scripts/validate/govcms-validate-active-permissions
@@ -54,7 +54,7 @@ done
 
 # Check the active database for 'is_admin'.
 for role in ${ROLES//,/ }; do
-  if [[ $(drush config:get "user.role.$role" is_admin --pipe) -eq 1 ]]; then
+  if [[ $(drush config:get "user.role.$role" is_admin --format=string) -eq 1 ]]; then
     echo "[FAIL]; '$role' has is_admin";
     FAILURES="$FAILURES,$role"
   fi


### PR DESCRIPTION
  - The current version was erroring out when running the validate-active-permissions script with the error `The "--pipe" option does not exist.`
  - New drush version has to use `--format=string` instead.