### PR TITLE
[DEVOPS-382] Added conditional AV check.

### DIFF
--- a/scripts/deploy/govcms-enable_modules
+++ b/scripts/deploy/govcms-enable_modules
@@ -33,10 +33,11 @@ fi
 
 MODULES=$("$DRUSH" pm:list --status=enabled)
 NON_PROD_MODULES=("stage_file_proxy")
+AV=$([ -z "$HTTPAV_ENDPOINT" ] && echo "clamav" || echo "httpav")
 PLATFORM_MODULES=(
   "redis"
   "fast404"
-  "clamav"
+  $AV
   "robotstxt"
   "lagoon_logs"
   "environment_indicator"


### PR DESCRIPTION
# Issue
As part of staged approach to rolling out HTTPAV, we will need to support both `clamav` and `httpav` until rollout is completed.

# Proposed solution
Add a conditional value for AV based on env variable.