### PR TITLE
Use explicit value for mailer_sendmail_commands.

### DIFF
--- a/drupal/settings/all.settings.php
+++ b/drupal/settings/all.settings.php
@@ -55,7 +55,7 @@ $settings['hash_salt'] = hash('sha256', getenv('MARIADB_HOST'));
 
 // Add custom symfony mailer transport command.
 $settings['mailer_sendmail_commands'] = [
-  ini_get('sendmail_path') . ' -t'
+  '/usr/sbin/sendmail -t -i'
 ];
 
 // Allow custom themes to provide custom 404 pages.


### PR DESCRIPTION
A safer model for setting the custom `mailer_sendmail_commands` as the php.ini value could change upstream.

Case in point: the ini value for `sendmail_path` now already includes `-t` where it didn't previously. Better to be explicit here.