### PR TITLE
[DEVOPS-382] Removed ClamAV checks.

### DIFF
--- a/shipshape.yml
+++ b/shipshape.yml
@@ -89,14 +89,6 @@ checks:
           truthy: true
         - key: required_roles.authenticated
           value: authenticated
-    - name: '[FILE] Ensure clamav is enabled'
-      file: clamav.settings.yml
-      ignore-missing: true
-      path: config/default
-      values:
-        - key: enabled
-          value: true
-          truthy: true
     - name: '[FILE] Ensure only admins can register accounts'
       file: user.settings.yml
       ignore-missing: true
@@ -146,14 +138,6 @@ checks:
           truthy: true
         - key: required_roles.authenticated
           value: authenticated
-    - name: '[DATABASE] Ensure clamav is enabled'
-      severity: high
-      command: 'config:get clamav.settings'
-      config-name: clamav.settings
-      values:
-        - key: enabled
-          value: true
-          truthy: true
     - name: '[DATABASE] Ensure only admins can register accounts'
       command: 'config:get user.settings'
       config-name: user.settings
@@ -181,7 +165,6 @@ checks:
       severity: high
       path: config/default
       required:
-        - clamav
         - govcms_security
         - lagoon_logs
         - tfa
@@ -195,7 +178,6 @@ checks:
     - name: '[DATABASE] Active modules audit'
       severity: high
       required:
-        - clamav
         - govcms_security
         - lagoon_logs
         - tfa


### PR DESCRIPTION
# Changes
As part of rolling out HTTP AV we need to disable ClamAV checks in ship shape configuration. These checks will be re-abled for HTTP AV when migration is completed for all projects.