### PR TITLE
Add php-http/discovery to the composer allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
       "cweagans/composer-patches": true,
       "drupal/core-composer-scaffold": true,
       "oomphinc/composer-installers-extender": true,
-      "phpstan/extension-installer": true
+      "phpstan/extension-installer": true,
+      "php-http/discovery": true
     },
     "apcu-autoloader": true,
     "optimize-autoloader": true


### PR DESCRIPTION
php-http/discovery plugin is needed as part of the update to core 10.2