### PR TITLE
Add google analytics to active module check.

### DIFF
--- a/shipshape.yml
+++ b/shipshape.yml
@@ -180,6 +180,7 @@ checks:
       required:
         - govcms_security
         - lagoon_logs
+        - google_analytics
         - tfa
       disallowed:
         - dblog


### PR DESCRIPTION
The active module check will be used as an audit so we can verify and remediate as required. This will allow us to easily report on which sites do not have the GA module enabled. 