### PR TITLE
fix: ensure audits inspect final config

### DIFF
--- a/scripts/validate/govcms-validate-active-tfa
+++ b/scripts/validate/govcms-validate-active-tfa
@@ -19,7 +19,7 @@ FAILURES=""
 
 echo "GovCMS Validate :: Validate TFA config on active site"
 
-TFA_CONFIG=$("$DRUSH" config:get tfa.settings --format=json)
+TFA_CONFIG=$("$DRUSH" config:get --include-overridden tfa.settings --format=json)
 
 TFA_ENABLED=$(jq -r '.enabled' <<< "${TFA_CONFIG}")
 if [[ "${TFA_ENABLED}" != 1 && "${TFA_ENABLED}" != 'true' ]]; then

--- a/shipshape.yml
+++ b/shipshape.yml
@@ -123,14 +123,14 @@ checks:
           value: theme
   drush-yaml:
     - name: '[DATABASE] Validate active install profile'
-      command: 'config:get core.extension'
+      command: 'config:get --include-overridden core.extension'
       config-name: core.extension
       values:
         - key: profile
           value: govcms
     - name: '[DATABASE] Validate active TFA'
       severity: high
-      command: 'config:get tfa.settings'
+      command: 'config:get --include-overridden tfa.settings'
       config-name: tfa.settings
       values:
         - key: enabled
@@ -139,13 +139,13 @@ checks:
         - key: required_roles.authenticated
           value: authenticated
     - name: '[DATABASE] Ensure only admins can register accounts'
-      command: 'config:get user.settings'
+      command: 'config:get --include-overridden user.settings'
       config-name: user.settings
       values:
         - key: register
           value: admin_only
     - name: '[DATABASE] Ensure CSS & JS aggregations are enabled'
-      command: 'config:get system.performance'
+      command: 'config:get --include-overridden system.performance'
       config-name: system.performance
       values:
         - key: css.preprocess
@@ -155,7 +155,7 @@ checks:
           value: true
           truthy: true
     - name: '[DATABASE] Ensure no error log displayed'
-      command: 'config:get system.logging'
+      command: 'config:get --include-overridden system.logging'
       config-name: user.settings
       values:
         - key: error_level


### PR DESCRIPTION
- adds the `--include-overridden` flag to `drush config:get` calls

False positives were identified in some cases when running Shipshape;  `--include-overridden` ensures the final config is inspected.

An example is:
```
$ drush config:get system.performance css
'system.performance:css':
  preprocess: false
  gzip: true

$ drush config:get system.performance js
'system.performance:js':
  preprocess: false
  gzip: true

$ drush config:get --include-overridden system.performance css
'system.performance:css':
  preprocess: 1
  gzip: true

$ drush config:get --include-overridden system.performance js
'system.performance:js':
  preprocess: 1
  gzip: true
```