### PR TITLE
[DEVOPS-438] Update yq syntax.

### DIFF
--- a/scripts/govcms-vet
+++ b/scripts/govcms-vet
@@ -14,11 +14,11 @@ CLIENTCODE="${WORKSPACE}/clientcode"
 SOURCE="$PWD"
 
 # Flavour (saas/paas) and version can be passed in to test a codebase.
-FLAVOUR=$(yq read .version.yml type)
+FLAVOUR=$(yq r .version.yml type)
 FLAVOUR=${1:-"$FLAVOUR"}
-VERSION=$(yq read .version.yml scaffold)
+VERSION=$(yq r .version.yml scaffold)
 VERSION=${2:-"$VERSION"}
-DRUPAL_VERSION=$(yq read .version.yml version)
+DRUPAL_VERSION=$(yq r .version.yml version)
 DRUPAL_VERSION=${3:-"$DRUPAL_VERSION"}
 
 

--- a/scripts/govcms-vet
+++ b/scripts/govcms-vet
@@ -14,11 +14,11 @@ CLIENTCODE="${WORKSPACE}/clientcode"
 SOURCE="$PWD"
 
 # Flavour (saas/paas) and version can be passed in to test a codebase.
-FLAVOUR=$(yq r .version.yml type)
+FLAVOUR=$(yq '.type' .version.yml)
 FLAVOUR=${1:-"$FLAVOUR"}
-VERSION=$(yq r .version.yml scaffold)
+VERSION=$(yq '.scaffold' .version.yml)
 VERSION=${2:-"$VERSION"}
-DRUPAL_VERSION=$(yq r .version.yml version)
+DRUPAL_VERSION=$(yq '.version' .version.yml)
 DRUPAL_VERSION=${3:-"$DRUPAL_VERSION"}
 
 


### PR DESCRIPTION
# Issue
The develop version of `govcms-ci` upgrades yq to version 4, which features a different syntax. We need to ensure that `scaffold-tooling` is up to date with that change.

