### PR TITLE
Updated PHPStan disallowed calls package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "drupal/fast_404": "3.3.0",
     "drupal/govcms_akamai_purge": "2.1.0",
     "phpstan/extension-installer": "1.3.1",
-    "spaze/phpstan-disallowed-calls": "2.16.1",
+    "spaze/phpstan-disallowed-calls": "^4.6.0",
     "cweagans/composer-patches": "1.7.3"
   },
   "require-dev": {


### PR DESCRIPTION
# Issue

The package is very outdated and it may be connected to us seeing false positives on disallowed methods calls like ` Cannot access constant` errors.

# Proposed solution
Update the package to the latest version.