### PR TITLE
Ignore false positives.

### DIFF
--- a/phpstan-extra.neon
+++ b/phpstan-extra.neon
@@ -20,6 +20,8 @@ parameters:
     - message: '#^Calling print_r\(\) is forbidden, please change the code$#'
       count: 1
       path: /app/web/themes/custom/bootstrap/src/Bootstrap.php
+    # Allow undefined constants to be ignored as they are not meant to be disallowed.  
+    - message: '#^Cannot access constant#'
   disallowedStaticCalls:
     - method: 'Drupal::httpClient()'
       message: 'please change the code'


### PR DESCRIPTION
# Issue
PHPStan Disallowed Calls package reports false positives `Cannot access constant` for Drupal constants. I believe that phpstan is scanning the theme directory without Drupal core available in the source repo so it reports those legit constants as errors. 

# Proposed solution
Add `Cannot access constant` errors to ignore as they do not belong to disallowed calls.