### PR TITLE
Release 5.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "drupal/fast_404": "3.3.0",
     "drupal/govcms_akamai_purge": "2.1.0",
     "phpstan/extension-installer": "1.3.1",
-    "spaze/phpstan-disallowed-calls": "2.16.1",
+    "spaze/phpstan-disallowed-calls": "^4.6.0",
     "cweagans/composer-patches": "1.7.3"
   },
   "require-dev": {

--- a/drupal/settings/security.settings.php
+++ b/drupal/settings/security.settings.php
@@ -61,6 +61,7 @@ $config['module_permissions.settings']['managed_modules'] = [
   'paragraphs',
   'pathauto',
   'shield',
+  'symfony_mailer'
   'recaptcha',
   'redirect',
   'redirect_404',

--- a/drupal/settings/security.settings.php
+++ b/drupal/settings/security.settings.php
@@ -61,7 +61,7 @@ $config['module_permissions.settings']['managed_modules'] = [
   'paragraphs',
   'pathauto',
   'shield',
-  'symfony_mailer'
+  'symfony_mailer',
   'recaptcha',
   'redirect',
   'redirect_404',

--- a/phpstan-extra.neon
+++ b/phpstan-extra.neon
@@ -20,6 +20,8 @@ parameters:
     - message: '#^Calling print_r\(\) is forbidden, please change the code$#'
       count: 1
       path: /app/web/themes/custom/bootstrap/src/Bootstrap.php
+    # Allow undefined constants to be ignored as they are not meant to be disallowed.  
+    - message: '#^Cannot access constant#'
   disallowedStaticCalls:
     - method: 'Drupal::httpClient()'
       message: 'please change the code'

--- a/scripts/deploy/govcms-enable_modules
+++ b/scripts/deploy/govcms-enable_modules
@@ -42,6 +42,7 @@ PLATFORM_MODULES=(
   "lagoon_logs"
   "environment_indicator"
   "govcms_security"
+  "govcms_akamai_purge"
 )
 
 MODULE_LIST=""

--- a/shipshape.yml
+++ b/shipshape.yml
@@ -170,6 +170,7 @@ checks:
       severity: high
       path: config/default
       required:
+        - govcms_akamai_purge
         - govcms_security
         - httpav
         - lagoon_logs

--- a/shipshape.yml
+++ b/shipshape.yml
@@ -191,6 +191,7 @@ checks:
     - name: '[DATABASE] Active modules audit'
       severity: high
       required:
+        - govcms_akamai_purge
         - govcms_security
         - httpav
         - lagoon_logs


### PR DESCRIPTION
- Add `symfony_mailer` to module permission configuration list
- Adds `govcms_akamai_purge` to required module list
- Fixes an issue with invalid class detection in PHPStan configuration