### PR TITLE
chore: update outdated Drush version to 13.x (13.5.0+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A variety of standard config, scripts and packages to support GovCMS scaffold.",
   "license": "GPL-2.0-or-later",
   "require": {
-    "drush/drush": "12.5.2",
+    "drush/drush": "13.6.2",
     "drupal/lagoon_logs": "^3.0 || ^2.1",
     "drupal/redis": "1.7.0",
     "drupal/stage_file_proxy": "3.1.5",


### PR DESCRIPTION
This PR updates the version of Drush used in the scaffold-tooling package to the latest release as at September 2025

As per https://www.drush.org/13.x/install/#drupal-compatibility - Drush 13 is compatible with PHP8.2+ and Drupal10.2+, both of which GovCMS SaaS satisfies. The 12.x branch of Drush doesn't see all features backported from 13.x

This release of Drush is needed to support enabling/disabling tls/ssl connections to the database, which is essential in newer releases of the upstream images.

closes https://github.com/govCMS/scaffold/issues/133