### PR TITLE
Update phpstan/extension-installer to version 1.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "drupal/purge": "3.6.0",
     "drupal/fast_404": "3.4.0",
     "drupal/govcms_akamai_purge": "2.2.0",
-    "phpstan/extension-installer": "1.3.1",
+    "phpstan/extension-installer": "1.4.3",
     "spaze/phpstan-disallowed-calls": "^4.6.0",
     "cweagans/composer-patches": "1.7.3"
   },


### PR DESCRIPTION
Drupal core 11.3.x requires 'phpstan/extension-installer' 1.4.3 and later version.

Reference:
https://git.drupalcode.org/project/drupal/-/blob/11.3.x/composer.json?ref_type=heads#L38