### PR TITLE
Fix db sync TLS errors on large imports

### DIFF
--- a/scripts/deploy/govcms-db-sync
+++ b/scripts/deploy/govcms-db-sync
@@ -113,7 +113,7 @@ EOF
 
   echo "[info]: Loading database using mysql"
   gunzip < /tmp/sync.sql.gz | mysql --defaults-file="$LOAD_TMP_FILE" \
-    --host="$DB_HOST" --port="$DB_PORT" "$DB_NAME"
+    --skip-ssl --max-allowed-packet=512M --host="$DB_HOST" --port="$DB_PORT" "$DB_NAME"
 else
   echo "[info]: Loading database using drush"
   gunzip < /tmp/sync.sql.gz | "$DRUSH" sqlc

--- a/scripts/deploy/govcms-db-sync
+++ b/scripts/deploy/govcms-db-sync
@@ -18,11 +18,10 @@ MARIADB_READREPLICA_HOSTS=${MARIADB_READREPLICA_HOSTS:-}
 GOVCMS_TEST_CANARY=${GOVCMS_TEST_CANARY:-FALSE}
 LAGOON_GIT_SAFE_BRANCH=${LAGOON_GIT_SAFE_BRANCH:-master}
 
-# For some projects with huge database sizes, the drush command might fail
-# due to the hardcoded drush timeout of 4 hours. If that happens, we have the
-# ability to set this variable to load the database via mysql directly,
-# thereby avoiding the drush timeout.
-DB_LOAD_NO_DRUSH=${DB_LOAD_NO_DRUSH:-FALSE}
+# Load the database via mysql directly instead of drush. This is the default
+# as it avoids the hardcoded drush timeout of 4 hours and removes PHP overhead.
+# Set to FALSE to revert to the legacy drush import path.
+DB_LOAD_NO_DRUSH=${DB_LOAD_NO_DRUSH:-TRUE}
 
 # Drush 12 support.
 DRUSH="${GOVCMS_DRUSH:-none}"

--- a/tests/bats/deploy/govcms-db-sync.bats
+++ b/tests/bats/deploy/govcms-db-sync.bats
@@ -288,4 +288,8 @@ setup() {
   assert_output_contains "[success]: Completed successfully."
   assert_equal 4 "$(mock_get_call_num "${mock_drush}")"
   assert_equal 1 "$(mock_get_call_num "${mock_mysql}")"
+
+  mysql_args="$(mock_get_call_args "${mock_mysql}" 1)"
+  [[ "$mysql_args" == *"--skip-ssl"* ]]
+  [[ "$mysql_args" == *"--max-allowed-packet=512M"* ]]
 }


### PR DESCRIPTION
The DB_LOAD_NO_DRUSH mysql import path was failing on projects with large databases — getting `ERROR 2026: TLS/SSL error: unexpected eof while reading` partway through the import.

- Add `--skip-ssl` since the connection is pod-to-service within the cluster
- Add `--max-allowed-packet=512M` to handle large extended INSERT statements