### PR TITLE
feat(deploy): add CONFIG_LOCAL_DIR overlay for local-only config overrides

### DIFF
--- a/scripts/deploy/govcms-config-import
+++ b/scripts/deploy/govcms-config-import
@@ -5,11 +5,26 @@ set -euo pipefail
 #
 # GovCMS configuration import.
 #
+# Configuration is imported from up to three directories, in this order:
+#
+#   1. CONFIG_DEFAULT_DIR (default /app/config/default) - full import,
+#      always.
+#   2. CONFIG_DEV_DIR (default /app/config/dev) - partial import on any
+#      non-production environment, when the directory contains YAML.
+#   3. CONFIG_LOCAL_DIR (default /app/config/local) - partial import only
+#      when LAGOON_ENVIRONMENT_TYPE=local AND the directory contains YAML.
+#
+# Each subsequent --partial import overrides keys set by the previous one,
+# so config/local/ is the place to put overrides that must apply ONLY to a
+# developer's local environment (e.g. disabling the shield module) without
+# affecting public Lagoon dev/staging/branch URLs.
+#
 
 LAGOON_ENVIRONMENT_TYPE=${LAGOON_ENVIRONMENT_TYPE:-production}
 GOVCMS_DEPLOY_WORKFLOW_CONFIG=${GOVCMS_DEPLOY_WORKFLOW_CONFIG:-import}
 CONFIG_DEFAULT_DIR=${CONFIG_DEFAULT_DIR:-/app/config/default}
 CONFIG_DEV_DIR=${CONFIG_DEV_DIR:-/app/config/dev}
+CONFIG_LOCAL_DIR=${CONFIG_LOCAL_DIR:-/app/config/local}
 LAGOON_GIT_SAFE_BRANCH=${LAGOON_GIT_SAFE_BRANCH:-master}
 
 # Drush 12 support.
@@ -42,9 +57,11 @@ set +e
 config_count=$(ls -1 "$CONFIG_DEFAULT_DIR"/*.yml 2>/dev/null | wc -l)
 # shellcheck disable=SC2012
 dev_config_count=$(ls -1 "$CONFIG_DEV_DIR"/*.yml 2>/dev/null | wc -l)
+# shellcheck disable=SC2012
+local_config_count=$(ls -1 "$CONFIG_LOCAL_DIR"/*.yml 2>/dev/null | wc -l)
 set -e
 
-if [ "$config_count" -eq 0 ] && [ "$dev_config_count" -eq 0 ]; then
+if [ "$config_count" -eq 0 ] && [ "$dev_config_count" -eq 0 ] && [ "$local_config_count" -eq 0 ]; then
   # There are no configuration files to import.
   echo "[skip]: There is no configuration."
   exit 0
@@ -64,6 +81,14 @@ fi
 if [ "$LAGOON_ENVIRONMENT_TYPE" != "production" ] && [ "$dev_config_count" -gt 0 ]; then
   echo "[update]: Import dev configuration partially."
   "$DRUSH" config:import -y --source="$CONFIG_DEV_DIR" --partial
+fi
+
+# Apply local-only overrides last so they win on local environments.
+# Intentionally gated on LAGOON_ENVIRONMENT_TYPE=local (not "non-production")
+# so that public Lagoon dev/staging/branch envs cannot pick up these overrides.
+if [ "$LAGOON_ENVIRONMENT_TYPE" = "local" ] && [ "$local_config_count" -gt 0 ]; then
+  echo "[update]: Import local configuration partially."
+  "$DRUSH" config:import -y --source="$CONFIG_LOCAL_DIR" --partial
 fi
 
 echo "[success]: Completed successfully."

--- a/tests/bats/deploy/fixtures/config/local/shield.settings.yml
+++ b/tests/bats/deploy/fixtures/config/local/shield.settings.yml
@@ -1,0 +1,11 @@
+# Sample fixture for CONFIG_LOCAL_DIR bats tests.
+#
+# Represents a typical local-only override: shield disabled on the
+# developer's machine without affecting public Lagoon dev/staging URLs.
+shield_enable: false
+credentials:
+  shield:
+    user: ''
+    pass: ''
+print: 'Restricted access.'
+allow_cli: true

--- a/tests/bats/deploy/govcms-config-import.bats
+++ b/tests/bats/deploy/govcms-config-import.bats
@@ -153,6 +153,129 @@ load ../_helpers_govcms
   assert_equal 3 "$(mock_get_call_num "${mock_drush}")"
 }
 
+################################################################################
+#                            CONFIG_LOCAL_DIR                                  #
+################################################################################
+
+# Workflow: import
+# dir: ./fixtures/config/default
+# devdir: ./fixtures/config/dev
+# localdir: ./fixtures/config/local
+# Local environment with all three dirs present applies all three imports
+# in order: default, dev, local. Local is partial and runs last.
+@test "Config import: local config (local env, all dirs)" {
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" '{"bootstrap": "Successful"}' 1
+
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=import
+  export LAGOON_ENVIRONMENT_TYPE="local"
+  export CONFIG_DEFAULT_DIR="tests/bats/deploy/fixtures/config/default"
+  export CONFIG_DEV_DIR="tests/bats/deploy/fixtures/config/dev"
+  export CONFIG_LOCAL_DIR="tests/bats/deploy/fixtures/config/local"
+
+  run scripts/deploy/govcms-config-import >&3
+
+  assert_output_contains "GovCMS Deploy :: Configuration import"
+  assert_output_contains "[update]: Import site configuration."
+  assert_output_contains "[update]: Import dev configuration partially."
+  assert_output_contains "[update]: Import local configuration partially."
+  assert_output_contains "[success]: Completed successfully."
+
+  assert_equal "config:import -y" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "config:import -y --source=${CONFIG_DEV_DIR} --partial" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal "config:import -y --source=${CONFIG_LOCAL_DIR} --partial" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal 4 "$(mock_get_call_num "${mock_drush}")"
+}
+
+# Workflow: import
+# dir: ./fixtures/config/default
+# devdir: ./fixtures/config/dev
+# localdir: /tmp/nodir (missing)
+# Local environment but no local dir on disk: behaves identically to a
+# regular non-prod run (default + dev only).
+@test "Config import: local config (local env, no local dir)" {
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" '{"bootstrap": "Successful"}' 1
+
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=import
+  export LAGOON_ENVIRONMENT_TYPE="local"
+  export CONFIG_DEFAULT_DIR="tests/bats/deploy/fixtures/config/default"
+  export CONFIG_DEV_DIR="tests/bats/deploy/fixtures/config/dev"
+  export CONFIG_LOCAL_DIR="/tmp/nodir"
+
+  run scripts/deploy/govcms-config-import >&3
+
+  assert_output_contains "GovCMS Deploy :: Configuration import"
+  assert_output_contains "[update]: Import site configuration."
+  assert_output_contains "[update]: Import dev configuration partially."
+  assert_output_contains "[success]: Completed successfully."
+
+  assert_output_not_contains "[update]: Import local configuration partially."
+
+  assert_equal "config:import -y" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "config:import -y --source=${CONFIG_DEV_DIR} --partial" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal 3 "$(mock_get_call_num "${mock_drush}")"
+}
+
+# Workflow: import
+# dir: ./fixtures/config/default
+# devdir: ./fixtures/config/dev
+# localdir: ./fixtures/config/local
+# Regression guard: development env must NOT pick up the local overlay even
+# if the local directory is present and configured.
+@test "Config import: local config not applied on development env" {
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" '{"bootstrap": "Successful"}' 1
+
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=import
+  export LAGOON_ENVIRONMENT_TYPE="development"
+  export CONFIG_DEFAULT_DIR="tests/bats/deploy/fixtures/config/default"
+  export CONFIG_DEV_DIR="tests/bats/deploy/fixtures/config/dev"
+  export CONFIG_LOCAL_DIR="tests/bats/deploy/fixtures/config/local"
+
+  run scripts/deploy/govcms-config-import >&3
+
+  assert_output_contains "GovCMS Deploy :: Configuration import"
+  assert_output_contains "[update]: Import site configuration."
+  assert_output_contains "[update]: Import dev configuration partially."
+  assert_output_contains "[success]: Completed successfully."
+
+  assert_output_not_contains "[update]: Import local configuration partially."
+
+  assert_equal "config:import -y" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal "config:import -y --source=${CONFIG_DEV_DIR} --partial" "$(mock_get_call_args "${mock_drush}" 3)"
+  assert_equal 3 "$(mock_get_call_num "${mock_drush}")"
+}
+
+# Workflow: import
+# dir: ./fixtures/config/default
+# devdir: ./fixtures/config/dev
+# localdir: ./fixtures/config/local
+# Production env: only the default import runs. Neither dev nor local
+# overlays may be applied, regardless of CONFIG_LOCAL_DIR contents.
+@test "Config import: local config not applied on production env" {
+  mock_drush=$(mock_command "drush")
+  mock_set_output "${mock_drush}" '{"bootstrap": "Successful"}' 1
+
+  export GOVCMS_DEPLOY_WORKFLOW_CONFIG=import
+  export LAGOON_ENVIRONMENT_TYPE="production"
+  export CONFIG_DEFAULT_DIR="tests/bats/deploy/fixtures/config/default"
+  export CONFIG_DEV_DIR="tests/bats/deploy/fixtures/config/dev"
+  export CONFIG_LOCAL_DIR="tests/bats/deploy/fixtures/config/local"
+
+  run scripts/deploy/govcms-config-import >&3
+
+  assert_output_contains "GovCMS Deploy :: Configuration import"
+  assert_output_contains "[update]: Import site configuration."
+  assert_output_contains "[success]: Completed successfully."
+
+  assert_output_not_contains "[update]: Import dev configuration partially."
+  assert_output_not_contains "[update]: Import local configuration partially."
+
+  assert_equal "config:import -y" "$(mock_get_call_args "${mock_drush}" 2)"
+  assert_equal 2 "$(mock_get_call_num "${mock_drush}")"
+}
+
 # Workflow: import
 # branch: update pattern
 @test "Config import: upgrade branch" {


### PR DESCRIPTION
Closes #387.

## Summary

Adds an optional `CONFIG_LOCAL_DIR` (default `/app/config/local`) overlay to `scripts/deploy/govcms-config-import`, applied via `drush config:import --partial` only when `LAGOON_ENVIRONMENT_TYPE=local` AND the directory contains importable YAML.

Overlay order: `default` → `dev` (any non-prod) → `local` (local only).

Lets site projects place `shield.settings.yml` (and any other local-only overrides) under `config/local/` to disable shield on developers' machines without weakening it on public Lagoon dev/staging/branch URLs.

## Why this matters

Today every non-production environment shares the same `config/dev/` overlay, so disabling shield for local also disables it on public dev URLs. This PR splits those concerns without changing existing behaviour for any environment that doesn't opt in.

## What changed

- `scripts/deploy/govcms-config-import`: read `CONFIG_LOCAL_DIR`, append a gated `--partial` import after the existing dev overlay. Header comment now documents the three-tier import order.
- `tests/bats/deploy/govcms-config-import.bats`: 4 new test cases (local+present, local+absent, development+present regression guard, production+present).
- `tests/bats/deploy/fixtures/config/local/shield.settings.yml`: new fixture matching the existing `dev` fixture pattern.

## What didn't change

- No changes to `scripts/govcms-deploy` or `drupal/settings/*`.
- No new runtime dependencies.
- Default behaviour for sites that don't add `config/local/` is identical to today.

## Backward compatibility

Fully backward compatible. The new code path is only reached when **both** `LAGOON_ENVIRONMENT_TYPE=local` and `CONFIG_LOCAL_DIR` contains YAML — neither is true for any existing GovCMS production or remote non-production environment.

## Security notes

- Gated on `LAGOON_ENVIRONMENT_TYPE=local`, set by the Lagoon local stack and not user-supplied at request time.
- Strengthens the current posture by removing the incentive to weaken shield in `config/dev/` for developer convenience.
- No changes to secret handling, no new code execution paths beyond `drush config:import`.

## Testing

```
$ bats tests/bats/deploy/govcms-config-import.bats
1..13
ok 1 Config import: defaults
ok 2 Config import: retain
ok 3 Config import: import
ok 4 Config import: default config
ok 5 Config import: dev config (production)
ok 6 Config import: dev config (nonprod)
ok 7 Config import: both dirs available (production)
ok 8 Config import: both dirs available (nonprod)
ok 9 Config import: local config (local env, all dirs)
ok 10 Config import: local config (local env, no local dir)
ok 11 Config import: local config not applied on development env
ok 12 Config import: local config not applied on production env
ok 13 Config import: upgrade branch
```

All 13 tests pass (9 pre-existing + 4 new).

Manual verification on a Compose-based GovCMS local stack:

1. Add `config/local/shield.settings.yml` with `shield_enable: false`.
2. Run `govcms-deploy` with `LAGOON_ENVIRONMENT_TYPE=local`.
3. Confirm shield is disabled locally and **still enabled** on a remote Lagoon dev environment for the same project.

## Adoption note for site projects

Once merged, a consuming GovCMS site project can:

1. Create `config/local/` in their project repo.
2. `drush config:export --destination=/app/config/local shield.settings` on a local instance with shield disabled, or hand-write the YAML.
3. Commit `config/local/shield.settings.yml`.

When their local stack sets `LAGOON_ENVIRONMENT_TYPE=local` (default for `pygmy`/`lando`/Compose-based GovCMS local dev), the next `govcms-deploy` will disable shield. Public Lagoon dev/staging URLs remain shielded.

## Follow-ups

- Consider a runtime `local.settings.php` companion in a future PR for settings overrides that shouldn't round-trip through `drush cex`.
