### PR TITLE
[GOVCMS-14902] Update to httpav 1.1.5 to properly disable scanning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "drupal/redis": "1.7.0",
     "drupal/stage_file_proxy": "3.1.5",
     "drupal/clamav": "2.0.2",
-    "drupal/httpav": "1.1.3",
+    "drupal/httpav": "1.1.5",
     "drupal/purge": "3.6.0",
     "drupal/fast_404": "3.3.0",
     "drupal/govcms_akamai_purge": "2.2.4",


### PR DESCRIPTION
Fixed a bug where disabling scanning in httpav config was not sticking.