### PR TITLE
[GOVCMS-14902] Update to httpav 1.3.3 to properly disable scanning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "drupal/lagoon_logs": "^3.0 || ^2.1",
     "drupal/redis": "1.11.0",
     "drupal/stage_file_proxy": "3.1.5",
-    "drupal/httpav": "1.3.1",
+    "drupal/httpav": "1.3.3",
     "drupal/purge": "3.6.0",
     "drupal/fast_404": "3.4.0",
     "drupal/govcms_akamai_purge": "2.2.5",


### PR DESCRIPTION
Fixed a bug where disabling scanning in httpav config was not sticking.