### PR TITLE
[GOVCMS-15152] Added enforcement of password policy.

### DIFF
--- a/drupal/settings/production.settings.php
+++ b/drupal/settings/production.settings.php
@@ -69,3 +69,6 @@ if (!empty(getenv('GOVCMS_TFA_ENFORCE'))) {
     $config['user.role.authenticated']['permissions'][999999] = 'setup own tfa';
   }
 }
+
+// Enforce password policy for all users.
+$config['password_policy.password_policy.austism']['roles']['authenticated'] = 'authenticated';


### PR DESCRIPTION
# Issue
Without any enforcement in the `settings.php`, customers can always bypass the settings via the `password_policy.password_policy.austism` config. Although `password_policy.*` is ignored in config_ignore, SaaS customers can always remove it from `config_ignore.settings` config to import their own policy, or even delete the policy from config.

# Proposed solution
Override the configuration via `settings.php`.